### PR TITLE
push 時にも CI の実行 / build_runner 用の設定を追加

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     types: [opened, synchronize]
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  push:
   pull_request:
     types: [opened, synchronize]
 

--- a/test/build.yaml
+++ b/test/build.yaml
@@ -1,0 +1,15 @@
+targets:
+  $default:
+    builders:
+      freezed:
+        generate_for:
+          include:
+            - lib/**/*.codegen.dart
+      json_serializable:
+        generate_for:
+          include:
+            - lib/**/*.codegen.dart
+      mockito:
+        generate_for:
+          include:
+            - test/**/*.dart


### PR DESCRIPTION
push 時にも CI を実行するように修正
また、build_runner の実行速度を少しでも短くするため、 `build.yaml` を追加

---

ref. https://twitter.com/_mono/status/1284299309647724544

#7 