### PR TITLE
Firebase Analytics のユーザプロパティの設定値を修正

### DIFF
--- a/lib/analytics.dart
+++ b/lib/analytics.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logger/logger.dart';
+import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
 import 'package:virtualpilgrimage/infrastructure/firebase/firebase_analytics_provider.dart';
 import 'package:virtualpilgrimage/logger.dart';
 
@@ -18,7 +19,7 @@ extension AnalyticsEvent on String {
 }
 
 final analyticsProvider = Provider<Analytics>(
-      (ref) => Analytics(ref.read(firebaseAnalyticsProvider), ref.read(loggerProvider)),
+  (ref) => Analytics(ref.read(firebaseAnalyticsProvider), ref.read(loggerProvider)),
 );
 
 class Analytics {
@@ -27,9 +28,14 @@ class Analytics {
   final FirebaseAnalytics _analytics;
   final Logger _logger;
 
-  Future<void> logEvent({required String eventName, Map<String, dynamic>? parameters}) async {
+  Future<void> logEvent({
+    required String eventName,
+    Map<String, dynamic>? parameters,
+  }) async {
     if (eventName.length > 40) {
-      _logger.w('firebase analytics log name must be 40 or less. [eventName][$eventName][parameters][$parameters]');
+      _logger.w(
+        'firebase analytics log name must be 40 or less. [eventName][$eventName][parameters][$parameters]',
+      );
       return Future.value();
     }
 
@@ -41,7 +47,14 @@ class Analytics {
     await _analytics.setCurrentScreen(screenName: screenName);
   }
 
-  Future<void> setUserProperties({required String name, String? value}) async {
-    unawaited(_analytics.setUserProperty(name: name, value: value));
+  Future<void> setUserProperties({required VirtualPilgrimageUser user}) async {
+    final map = {
+      VirtualPilgrimageUserPrivateFirestoreFieldKeys.id: user.id,
+      VirtualPilgrimageUserPrivateFirestoreFieldKeys.nickname: user.nickname,
+      VirtualPilgrimageUserPrivateFirestoreFieldKeys.gender: user.gender.name,
+    };
+    for (final entry in map.entries) {
+      unawaited(_analytics.setUserProperty(name: entry.key, value: entry.value));
+    }
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:virtualpilgrimage/analytics.dart';
 import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
 import 'package:virtualpilgrimage/gen/firebase_options_dev.dart' as dev;
 import 'package:virtualpilgrimage/gen/firebase_options_prod.dart' as prod;
@@ -24,15 +25,18 @@ class _App extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final router = ref.watch(routerProvider);
     final firebaseAuth = ref.watch(firebaseAuthProvider);
+    final analytics = ref.read(analyticsProvider);
     final userState = ref.watch(userStateProvider.state);
 
     // Firebaseへのログインがキャッシュされていれば
     // Firestoreからユーザ情報を詰める
     if (firebaseAuth.currentUser != null && userState.state == null) {
-      ref
-          .read(userRepositoryProvider)
-          .get(firebaseAuth.currentUser!.uid)
-          .then((value) => userState.state = value);
+      ref.read(userRepositoryProvider).get(firebaseAuth.currentUser!.uid).then((value) {
+        userState.state = value;
+        if (value != null) {
+          analytics.setUserProperties(user: value);
+        }
+      });
     }
 
     return MaterialApp.router(

--- a/lib/ui/pages/sign_in/sign_in_presenter.dart
+++ b/lib/ui/pages/sign_in/sign_in_presenter.dart
@@ -47,7 +47,7 @@ class SignInPresenter extends StateNotifier<SignInState> {
         email: state.email,
         password: state.password,
       );
-      unawaited(_analytics.setUserProperties(name: user.nickname, value: user.toString()));
+      unawaited(_analytics.setUserProperties(user: user));
       // userState を変更するとページが遷移するので最後に更新を実行
       _userState.state = user;
     } on Exception catch (e) {
@@ -93,7 +93,7 @@ class SignInPresenter extends StateNotifier<SignInState> {
       state = state.copyWith(
         context: _getSignInContext(user),
       );
-      unawaited(_analytics.setUserProperties(name: user.email, value: user.toString()));
+      unawaited(_analytics.setUserProperties(user: user));
       // userState を変更するとページが遷移するので最後に更新を実行
       _userState.state = user;
     } on SignInException catch (e) {
@@ -165,7 +165,6 @@ class SignInPresenter extends StateNotifier<SignInState> {
   Future<void> logout() async {
     await _analytics.logEvent(eventName: AnalyticsEvent.logout);
     await _signInUsecase.logout();
-    unawaited(_analytics.setUserProperties(name: 'not_logged_in'));
     _ref.watch(userStateProvider.state).state = null;
   }
 

--- a/test/analytics_test.dart
+++ b/test/analytics_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:logger/logger.dart';
 import 'package:mockito/mockito.dart';
 import 'package:virtualpilgrimage/analytics.dart';
+import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
 
 import 'helper/mock.mocks.dart';
 import 'helper/provider_container.dart';
@@ -55,7 +56,12 @@ void main() {
         await analytics.logEvent(eventName: eventName, parameters: parameters);
 
         // then
-        verifyNever(mockFirebaseAnalytics.logEvent(name: anyNamed('name'), parameters: anyNamed('parameters'))).called(0);
+        verifyNever(
+          mockFirebaseAnalytics.logEvent(
+            name: anyNamed('name'),
+            parameters: anyNamed('parameters'),
+          ),
+        ).called(0);
       });
     });
 
@@ -78,30 +84,41 @@ void main() {
     });
 
     group('setUserProperties', () {
-      test('正常系: value に値が設定される場合', () async {
+      test('正常系', () async {
         // given
-        const name = 'dummyName';
-        const value = 'User(name=dummyName, email=test@example.com)';
-        when(mockFirebaseAnalytics.setUserProperty(name: name, value: value))
-            .thenAnswer((_) => Future.value());
+        final user = VirtualPilgrimageUser(
+          id: 'dummyId',
+          nickname: 'dummyName',
+          gender: Gender.woman,
+          birthDay: DateTime(1990),
+        );
+        when(
+          mockFirebaseAnalytics.setUserProperty(
+            name: 'id',
+            value: 'dummyId',
+          ),
+        ).thenAnswer((_) => Future.value());
+        when(
+          mockFirebaseAnalytics.setUserProperty(
+            name: 'nickname',
+            value: 'dummyName',
+          ),
+        ).thenAnswer((_) => Future.value());
+        when(
+          mockFirebaseAnalytics.setUserProperty(
+            name: 'gender',
+            value: 'woman',
+          ),
+        ).thenAnswer((_) => Future.value());
 
         // when
-        await analytics.setUserProperties(name: name, value: value);
+        await analytics.setUserProperties(user: user);
 
         // then
-        verify(mockFirebaseAnalytics.setUserProperty(name: name, value: value)).called(1);
-      });
-
-      test('正常系: value に値が設定されない場合', () async {
-        // given
-        const name = 'dummyName';
-        when(mockFirebaseAnalytics.setUserProperty(name: name)).thenAnswer((_) => Future.value());
-
-        // when
-        await analytics.setUserProperties(name: name);
-
-        // then
-        verify(mockFirebaseAnalytics.setUserProperty(name: name)).called(1);
+        verify(mockFirebaseAnalytics.setUserProperty(name: 'id', value: 'dummyId')).called(1);
+        verify(mockFirebaseAnalytics.setUserProperty(name: 'nickname', value: 'dummyName'))
+            .called(1);
+        verify(mockFirebaseAnalytics.setUserProperty(name: 'gender', value: 'woman')).called(1);
       });
     });
   });


### PR DESCRIPTION
@itomizu 

Firebase Analytics にログを送るときに設定しているユーザプロパティの設定方法が誤っていたため修正しました 🙇‍♂️ 
正しい利用方法は https://pub.dev/packages/firebase_analytics/example が参考になります。

`setUserProperty(name: 'key', value: 'value')` のように設定する必要がありました。

軽微な修正であるため、動作が確認できたらセルフマージします。