### PR TITLE
CloudStorageからの画像表示対応

### DIFF
--- a/lib/domain/user/pilgrimage/pilgrimage_info.codegen.dart
+++ b/lib/domain/user/pilgrimage/pilgrimage_info.codegen.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'pilgrimage_info.codegen.freezed.dart';
+part 'pilgrimage_info.codegen.g.dart';
+
+@freezed
+class PilgrimageInfo with _$PilgrimageInfo {
+  @JsonSerializable(explicitToJson: true)
+  const factory PilgrimageInfo({
+    @Default('')
+      String id,
+    @Default('1')
+      String nowPilgrimageId,
+    @Default('')
+      String lap,
+}) = _PilgrimageInfo;
+  const PilgrimageInfo._();
+
+  factory PilgrimageInfo.fromJson(Map<String, dynamic> json) => _$PilgrimageInfoFromJson(json);
+}

--- a/lib/domain/user/pilgrimage/pilgrimage_info.codegen.dart
+++ b/lib/domain/user/pilgrimage/pilgrimage_info.codegen.dart
@@ -7,12 +7,9 @@ part 'pilgrimage_info.codegen.g.dart';
 class PilgrimageInfo with _$PilgrimageInfo {
   @JsonSerializable(explicitToJson: true)
   const factory PilgrimageInfo({
-    @Default('')
-      String id,
-    @Default('1')
-      String nowPilgrimageId,
-    @Default('')
-      String lap,
+    required int id,
+    required int nowPilgrimageId,
+    required int lap,
 }) = _PilgrimageInfo;
   const PilgrimageInfo._();
 

--- a/lib/domain/user/pilgrimage/pilgrimage_info.codegen.freezed.dart
+++ b/lib/domain/user/pilgrimage/pilgrimage_info.codegen.freezed.dart
@@ -20,9 +20,9 @@ PilgrimageInfo _$PilgrimageInfoFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$PilgrimageInfo {
-  String get id => throw _privateConstructorUsedError;
-  String get nowPilgrimageId => throw _privateConstructorUsedError;
-  String get lap => throw _privateConstructorUsedError;
+  int get id => throw _privateConstructorUsedError;
+  int get nowPilgrimageId => throw _privateConstructorUsedError;
+  int get lap => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -35,7 +35,7 @@ abstract class $PilgrimageInfoCopyWith<$Res> {
   factory $PilgrimageInfoCopyWith(
           PilgrimageInfo value, $Res Function(PilgrimageInfo) then) =
       _$PilgrimageInfoCopyWithImpl<$Res>;
-  $Res call({String id, String nowPilgrimageId, String lap});
+  $Res call({int id, int nowPilgrimageId, int lap});
 }
 
 /// @nodoc
@@ -57,15 +57,15 @@ class _$PilgrimageInfoCopyWithImpl<$Res>
       id: id == freezed
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
-              as String,
+              as int,
       nowPilgrimageId: nowPilgrimageId == freezed
           ? _value.nowPilgrimageId
           : nowPilgrimageId // ignore: cast_nullable_to_non_nullable
-              as String,
+              as int,
       lap: lap == freezed
           ? _value.lap
           : lap // ignore: cast_nullable_to_non_nullable
-              as String,
+              as int,
     ));
   }
 }
@@ -77,7 +77,7 @@ abstract class _$$_PilgrimageInfoCopyWith<$Res>
           _$_PilgrimageInfo value, $Res Function(_$_PilgrimageInfo) then) =
       __$$_PilgrimageInfoCopyWithImpl<$Res>;
   @override
-  $Res call({String id, String nowPilgrimageId, String lap});
+  $Res call({int id, int nowPilgrimageId, int lap});
 }
 
 /// @nodoc
@@ -101,15 +101,15 @@ class __$$_PilgrimageInfoCopyWithImpl<$Res>
       id: id == freezed
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
-              as String,
+              as int,
       nowPilgrimageId: nowPilgrimageId == freezed
           ? _value.nowPilgrimageId
           : nowPilgrimageId // ignore: cast_nullable_to_non_nullable
-              as String,
+              as int,
       lap: lap == freezed
           ? _value.lap
           : lap // ignore: cast_nullable_to_non_nullable
-              as String,
+              as int,
     ));
   }
 }
@@ -119,21 +119,18 @@ class __$$_PilgrimageInfoCopyWithImpl<$Res>
 @JsonSerializable(explicitToJson: true)
 class _$_PilgrimageInfo extends _PilgrimageInfo {
   const _$_PilgrimageInfo(
-      {this.id = '', this.nowPilgrimageId = '1', this.lap = ''})
+      {required this.id, required this.nowPilgrimageId, required this.lap})
       : super._();
 
   factory _$_PilgrimageInfo.fromJson(Map<String, dynamic> json) =>
       _$$_PilgrimageInfoFromJson(json);
 
   @override
-  @JsonKey()
-  final String id;
+  final int id;
   @override
-  @JsonKey()
-  final String nowPilgrimageId;
+  final int nowPilgrimageId;
   @override
-  @JsonKey()
-  final String lap;
+  final int lap;
 
   @override
   String toString() {
@@ -174,20 +171,20 @@ class _$_PilgrimageInfo extends _PilgrimageInfo {
 
 abstract class _PilgrimageInfo extends PilgrimageInfo {
   const factory _PilgrimageInfo(
-      {final String id,
-      final String nowPilgrimageId,
-      final String lap}) = _$_PilgrimageInfo;
+      {required final int id,
+      required final int nowPilgrimageId,
+      required final int lap}) = _$_PilgrimageInfo;
   const _PilgrimageInfo._() : super._();
 
   factory _PilgrimageInfo.fromJson(Map<String, dynamic> json) =
       _$_PilgrimageInfo.fromJson;
 
   @override
-  String get id;
+  int get id;
   @override
-  String get nowPilgrimageId;
+  int get nowPilgrimageId;
   @override
-  String get lap;
+  int get lap;
   @override
   @JsonKey(ignore: true)
   _$$_PilgrimageInfoCopyWith<_$_PilgrimageInfo> get copyWith =>

--- a/lib/domain/user/pilgrimage/pilgrimage_info.codegen.freezed.dart
+++ b/lib/domain/user/pilgrimage/pilgrimage_info.codegen.freezed.dart
@@ -1,0 +1,195 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'pilgrimage_info.codegen.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+PilgrimageInfo _$PilgrimageInfoFromJson(Map<String, dynamic> json) {
+  return _PilgrimageInfo.fromJson(json);
+}
+
+/// @nodoc
+mixin _$PilgrimageInfo {
+  String get id => throw _privateConstructorUsedError;
+  String get nowPilgrimageId => throw _privateConstructorUsedError;
+  String get lap => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $PilgrimageInfoCopyWith<PilgrimageInfo> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PilgrimageInfoCopyWith<$Res> {
+  factory $PilgrimageInfoCopyWith(
+          PilgrimageInfo value, $Res Function(PilgrimageInfo) then) =
+      _$PilgrimageInfoCopyWithImpl<$Res>;
+  $Res call({String id, String nowPilgrimageId, String lap});
+}
+
+/// @nodoc
+class _$PilgrimageInfoCopyWithImpl<$Res>
+    implements $PilgrimageInfoCopyWith<$Res> {
+  _$PilgrimageInfoCopyWithImpl(this._value, this._then);
+
+  final PilgrimageInfo _value;
+  // ignore: unused_field
+  final $Res Function(PilgrimageInfo) _then;
+
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? nowPilgrimageId = freezed,
+    Object? lap = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: id == freezed
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      nowPilgrimageId: nowPilgrimageId == freezed
+          ? _value.nowPilgrimageId
+          : nowPilgrimageId // ignore: cast_nullable_to_non_nullable
+              as String,
+      lap: lap == freezed
+          ? _value.lap
+          : lap // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$$_PilgrimageInfoCopyWith<$Res>
+    implements $PilgrimageInfoCopyWith<$Res> {
+  factory _$$_PilgrimageInfoCopyWith(
+          _$_PilgrimageInfo value, $Res Function(_$_PilgrimageInfo) then) =
+      __$$_PilgrimageInfoCopyWithImpl<$Res>;
+  @override
+  $Res call({String id, String nowPilgrimageId, String lap});
+}
+
+/// @nodoc
+class __$$_PilgrimageInfoCopyWithImpl<$Res>
+    extends _$PilgrimageInfoCopyWithImpl<$Res>
+    implements _$$_PilgrimageInfoCopyWith<$Res> {
+  __$$_PilgrimageInfoCopyWithImpl(
+      _$_PilgrimageInfo _value, $Res Function(_$_PilgrimageInfo) _then)
+      : super(_value, (v) => _then(v as _$_PilgrimageInfo));
+
+  @override
+  _$_PilgrimageInfo get _value => super._value as _$_PilgrimageInfo;
+
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? nowPilgrimageId = freezed,
+    Object? lap = freezed,
+  }) {
+    return _then(_$_PilgrimageInfo(
+      id: id == freezed
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      nowPilgrimageId: nowPilgrimageId == freezed
+          ? _value.nowPilgrimageId
+          : nowPilgrimageId // ignore: cast_nullable_to_non_nullable
+              as String,
+      lap: lap == freezed
+          ? _value.lap
+          : lap // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true)
+class _$_PilgrimageInfo extends _PilgrimageInfo {
+  const _$_PilgrimageInfo(
+      {this.id = '', this.nowPilgrimageId = '1', this.lap = ''})
+      : super._();
+
+  factory _$_PilgrimageInfo.fromJson(Map<String, dynamic> json) =>
+      _$$_PilgrimageInfoFromJson(json);
+
+  @override
+  @JsonKey()
+  final String id;
+  @override
+  @JsonKey()
+  final String nowPilgrimageId;
+  @override
+  @JsonKey()
+  final String lap;
+
+  @override
+  String toString() {
+    return 'PilgrimageInfo(id: $id, nowPilgrimageId: $nowPilgrimageId, lap: $lap)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_PilgrimageInfo &&
+            const DeepCollectionEquality().equals(other.id, id) &&
+            const DeepCollectionEquality()
+                .equals(other.nowPilgrimageId, nowPilgrimageId) &&
+            const DeepCollectionEquality().equals(other.lap, lap));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(id),
+      const DeepCollectionEquality().hash(nowPilgrimageId),
+      const DeepCollectionEquality().hash(lap));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_PilgrimageInfoCopyWith<_$_PilgrimageInfo> get copyWith =>
+      __$$_PilgrimageInfoCopyWithImpl<_$_PilgrimageInfo>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_PilgrimageInfoToJson(
+      this,
+    );
+  }
+}
+
+abstract class _PilgrimageInfo extends PilgrimageInfo {
+  const factory _PilgrimageInfo(
+      {final String id,
+      final String nowPilgrimageId,
+      final String lap}) = _$_PilgrimageInfo;
+  const _PilgrimageInfo._() : super._();
+
+  factory _PilgrimageInfo.fromJson(Map<String, dynamic> json) =
+      _$_PilgrimageInfo.fromJson;
+
+  @override
+  String get id;
+  @override
+  String get nowPilgrimageId;
+  @override
+  String get lap;
+  @override
+  @JsonKey(ignore: true)
+  _$$_PilgrimageInfoCopyWith<_$_PilgrimageInfo> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/domain/user/pilgrimage/pilgrimage_info.codegen.g.dart
+++ b/lib/domain/user/pilgrimage/pilgrimage_info.codegen.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pilgrimage_info.codegen.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_PilgrimageInfo _$$_PilgrimageInfoFromJson(Map<String, dynamic> json) =>
+    _$_PilgrimageInfo(
+      id: json['id'] as String? ?? '',
+      nowPilgrimageId: json['nowPilgrimageId'] as String? ?? '1',
+      lap: json['lap'] as String? ?? '',
+    );
+
+Map<String, dynamic> _$$_PilgrimageInfoToJson(_$_PilgrimageInfo instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'nowPilgrimageId': instance.nowPilgrimageId,
+      'lap': instance.lap,
+    };

--- a/lib/domain/user/pilgrimage/pilgrimage_info.codegen.g.dart
+++ b/lib/domain/user/pilgrimage/pilgrimage_info.codegen.g.dart
@@ -8,9 +8,9 @@ part of 'pilgrimage_info.codegen.dart';
 
 _$_PilgrimageInfo _$$_PilgrimageInfoFromJson(Map<String, dynamic> json) =>
     _$_PilgrimageInfo(
-      id: json['id'] as String? ?? '',
-      nowPilgrimageId: json['nowPilgrimageId'] as String? ?? '1',
-      lap: json['lap'] as String? ?? '',
+      id: json['id'] as int,
+      nowPilgrimageId: json['nowPilgrimageId'] as int,
+      lap: json['lap'] as int,
     );
 
 Map<String, dynamic> _$$_PilgrimageInfoToJson(_$_PilgrimageInfo instance) =>

--- a/lib/domain/user/pilgrimage/pilgrimage_repository.dart
+++ b/lib/domain/user/pilgrimage/pilgrimage_repository.dart
@@ -1,27 +1,15 @@
-import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:logger/logger.dart';
 import 'package:virtualpilgrimage/infrastructure/firebase/storage_provider.dart';
+import 'package:virtualpilgrimage/infrastructure/user/pilgrimage_repository_impl.dart';
 import 'package:virtualpilgrimage/logger.dart';
 
 final pilgrimageRepositoryProvider = Provider<PilgrimageRepository>(
-  (ref) => PilgrimageRepository(
+  (ref) => PilgrimageRepositoryImpl(
     ref.read(storageProvider),
     ref.read(loggerProvider),
   ),
 );
 
-class PilgrimageRepository {
-  PilgrimageRepository(this._firestoreClient, this._logger);
-
-  final FirebaseStorage _firestoreClient;
-  final Logger _logger;
-
-  Future<String> getTempleImageUrl(String pilgrimageId, String filename) async {
-    final storageRef = _firestoreClient.ref().child('temples/$pilgrimageId/$filename');
-
-    _logger.d(filename);
-
-    return storageRef.getDownloadURL();
-  }
+abstract class PilgrimageRepository {
+  Future<String> getTempleImageUrl(String pilgrimageId, String filename);
 }

--- a/lib/domain/user/pilgrimage/pilgrimage_repository.dart
+++ b/lib/domain/user/pilgrimage/pilgrimage_repository.dart
@@ -1,0 +1,27 @@
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logger/logger.dart';
+import 'package:virtualpilgrimage/infrastructure/firebase/storage_provider.dart';
+import 'package:virtualpilgrimage/logger.dart';
+
+final pilgrimageRepositoryProvider = Provider<PilgrimageRepository>(
+  (ref) => PilgrimageRepository(
+    ref.read(storageProvider),
+    ref.read(loggerProvider),
+  ),
+);
+
+class PilgrimageRepository {
+  PilgrimageRepository(this._firestoreClient, this._logger);
+
+  final FirebaseStorage _firestoreClient;
+  final Logger _logger;
+
+  Future<String> getTempleImageUrl(String pilgrimageId, String filename) async {
+    final storageRef = _firestoreClient.ref().child('temples/$pilgrimageId/$filename');
+
+    _logger.d(filename);
+
+    return storageRef.getDownloadURL();
+  }
+}

--- a/lib/domain/user/virtual_pilgrimage_user.codegen.dart
+++ b/lib/domain/user/virtual_pilgrimage_user.codegen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:virtualpilgrimage/domain/user/health/health_info.codegen.dart';
+import 'package:virtualpilgrimage/domain/user/pilgrimage/pilgrimage_info.codegen.dart';
 
 part 'virtual_pilgrimage_user.codegen.freezed.dart';
 part 'virtual_pilgrimage_user.codegen.g.dart';
@@ -129,6 +130,7 @@ class VirtualPilgrimageUser with _$VirtualPilgrimageUser {
     @JsonKey(ignore: true, fromJson: _BitmapConverter.stringToBitmap)
     @Default(BitmapDescriptor.defaultMarker)
         BitmapDescriptor userIcon,
+    PilgrimageInfo? pilgrimage,
   }) = _VirtualPilgrimageUser;
 
   const VirtualPilgrimageUser._();

--- a/lib/domain/user/virtual_pilgrimage_user.codegen.freezed.dart
+++ b/lib/domain/user/virtual_pilgrimage_user.codegen.freezed.dart
@@ -55,6 +55,7 @@ mixin _$VirtualPilgrimageUser {
 // ユーザアイコン。ログイン時に userIconUrl から GoogleMap に描画できる形式に変換される
   @JsonKey(ignore: true, fromJson: _BitmapConverter.stringToBitmap)
   BitmapDescriptor get userIcon => throw _privateConstructorUsedError;
+  PilgrimageInfo? get pilgrimage => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -84,9 +85,11 @@ abstract class $VirtualPilgrimageUserCopyWith<$Res> {
           DateTime updatedAt,
       HealthInfo? health,
       @JsonKey(ignore: true, fromJson: _BitmapConverter.stringToBitmap)
-          BitmapDescriptor userIcon});
+          BitmapDescriptor userIcon,
+      PilgrimageInfo? pilgrimage});
 
   $HealthInfoCopyWith<$Res>? get health;
+  $PilgrimageInfoCopyWith<$Res>? get pilgrimage;
 }
 
 /// @nodoc
@@ -111,6 +114,7 @@ class _$VirtualPilgrimageUserCopyWithImpl<$Res>
     Object? updatedAt = freezed,
     Object? health = freezed,
     Object? userIcon = freezed,
+    Object? pilgrimage = freezed,
   }) {
     return _then(_value.copyWith(
       id: id == freezed
@@ -157,6 +161,10 @@ class _$VirtualPilgrimageUserCopyWithImpl<$Res>
           ? _value.userIcon
           : userIcon // ignore: cast_nullable_to_non_nullable
               as BitmapDescriptor,
+      pilgrimage: pilgrimage == freezed
+          ? _value.pilgrimage
+          : pilgrimage // ignore: cast_nullable_to_non_nullable
+              as PilgrimageInfo?,
     ));
   }
 
@@ -168,6 +176,17 @@ class _$VirtualPilgrimageUserCopyWithImpl<$Res>
 
     return $HealthInfoCopyWith<$Res>(_value.health!, (value) {
       return _then(_value.copyWith(health: value));
+    });
+  }
+
+  @override
+  $PilgrimageInfoCopyWith<$Res>? get pilgrimage {
+    if (_value.pilgrimage == null) {
+      return null;
+    }
+
+    return $PilgrimageInfoCopyWith<$Res>(_value.pilgrimage!, (value) {
+      return _then(_value.copyWith(pilgrimage: value));
     });
   }
 }
@@ -196,10 +215,13 @@ abstract class _$$_VirtualPilgrimageUserCopyWith<$Res>
           DateTime updatedAt,
       HealthInfo? health,
       @JsonKey(ignore: true, fromJson: _BitmapConverter.stringToBitmap)
-          BitmapDescriptor userIcon});
+          BitmapDescriptor userIcon,
+      PilgrimageInfo? pilgrimage});
 
   @override
   $HealthInfoCopyWith<$Res>? get health;
+  @override
+  $PilgrimageInfoCopyWith<$Res>? get pilgrimage;
 }
 
 /// @nodoc
@@ -227,6 +249,7 @@ class __$$_VirtualPilgrimageUserCopyWithImpl<$Res>
     Object? updatedAt = freezed,
     Object? health = freezed,
     Object? userIcon = freezed,
+    Object? pilgrimage = freezed,
   }) {
     return _then(_$_VirtualPilgrimageUser(
       id: id == freezed
@@ -273,6 +296,10 @@ class __$$_VirtualPilgrimageUserCopyWithImpl<$Res>
           ? _value.userIcon
           : userIcon // ignore: cast_nullable_to_non_nullable
               as BitmapDescriptor,
+      pilgrimage: pilgrimage == freezed
+          ? _value.pilgrimage
+          : pilgrimage // ignore: cast_nullable_to_non_nullable
+              as PilgrimageInfo?,
     ));
   }
 }
@@ -298,7 +325,8 @@ class _$_VirtualPilgrimageUser extends _VirtualPilgrimageUser {
           required this.updatedAt,
       this.health,
       @JsonKey(ignore: true, fromJson: _BitmapConverter.stringToBitmap)
-          this.userIcon = BitmapDescriptor.defaultMarker})
+          this.userIcon = BitmapDescriptor.defaultMarker,
+      this.pilgrimage})
       : super._();
 
   factory _$_VirtualPilgrimageUser.fromJson(Map<String, dynamic> json) =>
@@ -360,10 +388,12 @@ class _$_VirtualPilgrimageUser extends _VirtualPilgrimageUser {
   @override
   @JsonKey(ignore: true, fromJson: _BitmapConverter.stringToBitmap)
   final BitmapDescriptor userIcon;
+  @override
+  final PilgrimageInfo? pilgrimage;
 
   @override
   String toString() {
-    return 'VirtualPilgrimageUser(id: $id, nickname: $nickname, gender: $gender, birthDay: $birthDay, email: $email, userIconUrl: $userIconUrl, userStatus: $userStatus, createdAt: $createdAt, updatedAt: $updatedAt, health: $health, userIcon: $userIcon)';
+    return 'VirtualPilgrimageUser(id: $id, nickname: $nickname, gender: $gender, birthDay: $birthDay, email: $email, userIconUrl: $userIconUrl, userStatus: $userStatus, createdAt: $createdAt, updatedAt: $updatedAt, health: $health, userIcon: $userIcon, pilgrimage: $pilgrimage)';
   }
 
   @override
@@ -383,7 +413,9 @@ class _$_VirtualPilgrimageUser extends _VirtualPilgrimageUser {
             const DeepCollectionEquality().equals(other.createdAt, createdAt) &&
             const DeepCollectionEquality().equals(other.updatedAt, updatedAt) &&
             const DeepCollectionEquality().equals(other.health, health) &&
-            const DeepCollectionEquality().equals(other.userIcon, userIcon));
+            const DeepCollectionEquality().equals(other.userIcon, userIcon) &&
+            const DeepCollectionEquality()
+                .equals(other.pilgrimage, pilgrimage));
   }
 
   @JsonKey(ignore: true)
@@ -400,7 +432,8 @@ class _$_VirtualPilgrimageUser extends _VirtualPilgrimageUser {
       const DeepCollectionEquality().hash(createdAt),
       const DeepCollectionEquality().hash(updatedAt),
       const DeepCollectionEquality().hash(health),
-      const DeepCollectionEquality().hash(userIcon));
+      const DeepCollectionEquality().hash(userIcon),
+      const DeepCollectionEquality().hash(pilgrimage));
 
   @JsonKey(ignore: true)
   @override
@@ -434,7 +467,8 @@ abstract class _VirtualPilgrimageUser extends VirtualPilgrimageUser {
           required final DateTime updatedAt,
       final HealthInfo? health,
       @JsonKey(ignore: true, fromJson: _BitmapConverter.stringToBitmap)
-          final BitmapDescriptor userIcon}) = _$_VirtualPilgrimageUser;
+          final BitmapDescriptor userIcon,
+      final PilgrimageInfo? pilgrimage}) = _$_VirtualPilgrimageUser;
   const _VirtualPilgrimageUser._() : super._();
 
   factory _VirtualPilgrimageUser.fromJson(Map<String, dynamic> json) =
@@ -482,6 +516,8 @@ abstract class _VirtualPilgrimageUser extends VirtualPilgrimageUser {
 // ユーザアイコン。ログイン時に userIconUrl から GoogleMap に描画できる形式に変換される
   @JsonKey(ignore: true, fromJson: _BitmapConverter.stringToBitmap)
   BitmapDescriptor get userIcon;
+  @override
+  PilgrimageInfo? get pilgrimage;
   @override
   @JsonKey(ignore: true)
   _$$_VirtualPilgrimageUserCopyWith<_$_VirtualPilgrimageUser> get copyWith =>

--- a/lib/domain/user/virtual_pilgrimage_user.codegen.g.dart
+++ b/lib/domain/user/virtual_pilgrimage_user.codegen.g.dart
@@ -29,6 +29,9 @@ _$_VirtualPilgrimageUser _$$_VirtualPilgrimageUserFromJson(
       health: json['health'] == null
           ? null
           : HealthInfo.fromJson(json['health'] as Map<String, dynamic>),
+      pilgrimage: json['pilgrimage'] == null
+          ? null
+          : PilgrimageInfo.fromJson(json['pilgrimage'] as Map<String, dynamic>),
     );
 
 Map<String, dynamic> _$$_VirtualPilgrimageUserToJson(
@@ -47,4 +50,5 @@ Map<String, dynamic> _$$_VirtualPilgrimageUserToJson(
       'updatedAt':
           _FirestoreTimestampConverter.dateTimeToTimestamp(instance.updatedAt),
       'health': instance.health?.toJson(),
+      'pilgrimage': instance.pilgrimage?.toJson(),
     };

--- a/lib/infrastructure/firebase/storage_provider.dart
+++ b/lib/infrastructure/firebase/storage_provider.dart
@@ -1,0 +1,6 @@
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final storageProvider = Provider<FirebaseStorage>(
+  (_) => FirebaseStorage.instance,
+);

--- a/lib/infrastructure/user/pilgrimage_repository_impl.dart
+++ b/lib/infrastructure/user/pilgrimage_repository_impl.dart
@@ -1,0 +1,20 @@
+
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:logger/logger.dart';
+import 'package:virtualpilgrimage/domain/user/pilgrimage/pilgrimage_repository.dart';
+
+class PilgrimageRepositoryImpl implements PilgrimageRepository {
+  PilgrimageRepositoryImpl(this._firestoreClient, this._logger);
+
+  final FirebaseStorage _firestoreClient;
+  final Logger _logger;
+
+  @override
+  Future<String> getTempleImageUrl(String pilgrimageId, String filename) async {
+    final storageRef = _firestoreClient.ref().child('temples/$pilgrimageId/$filename');
+
+    _logger.d(filename);
+
+    return storageRef.getDownloadURL();
+  }
+}

--- a/lib/ui/pages/home/home_page.dart
+++ b/lib/ui/pages/home/home_page.dart
@@ -86,7 +86,7 @@ class HomePageBody extends StatelessWidget {
             ElevatedButton(
               onPressed: () async {
                 final pilgrimage = _ref.watch(pilgrimageRepositoryProvider);
-                final url = await pilgrimage.getTempleImageUrl(userState?.pilgrimage?.nowPilgrimageId ?? '1', '1.jpg');
+                final url = await pilgrimage.getTempleImageUrl(userState?.pilgrimage?.nowPilgrimageId.toString() ?? '1', '1.jpg');
                 await showDialog<void>(
                   context: context,
                   builder: (BuildContext context) {

--- a/lib/ui/pages/home/home_page.dart
+++ b/lib/ui/pages/home/home_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
+import 'package:virtualpilgrimage/domain/user/pilgrimage/pilgrimage_repository.dart';
 import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
 import 'package:virtualpilgrimage/router.dart';
 import 'package:virtualpilgrimage/ui/pages/home/components/google_map_view.dart';
@@ -81,6 +82,28 @@ class HomePageBody extends StatelessWidget {
                 _ref.read(routerProvider).go(RouterPath.signIn);
               },
               child: const Text('サインイン画面に戻る'),
+            ),
+            ElevatedButton(
+              onPressed: () async {
+                final pilgrimage = _ref.watch(pilgrimageRepositoryProvider);
+                final url = await pilgrimage.getTempleImageUrl(userState?.pilgrimage?.nowPilgrimageId ?? '1', '1.jpg');
+                await showDialog<void>(
+                  context: context,
+                  builder: (BuildContext context) {
+                    return AlertDialog(
+                      title: const Text('付近のお寺情報'),
+                      content: Image.network(url),
+                      actions: <Widget>[
+                        ElevatedButton(
+                          onPressed: () => Navigator.pop(context),
+                          child: const Text('閉じる'),
+                        ),
+                      ],
+                    );
+                  },
+                );
+              },
+              child: const Text('お寺の情報を表示する'),
             ),
             const Padding(
               padding: EdgeInsetsDirectional.all(16),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -315,14 +315,14 @@ packages:
       name: firebase_core_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.5.0"
+    version: "4.5.1"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.1"
+    version: "1.7.3"
   firebase_crashlytics:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -337,6 +337,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.2.13"
+  firebase_storage:
+    dependency: "direct main"
+    description:
+      name: firebase_storage
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "10.3.8"
+  firebase_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_storage_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.1.16"
+  firebase_storage_web:
+    dependency: transitive
+    description:
+      name: firebase_storage_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.3.6"
   fixnum:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,7 @@ dependencies:
   # health
   health: ^4.1.1
   permission_handler: ^9.2.0 # Firebaseと同じSDKをターゲットにできるよう最新ではないバージョンを利用
+  firebase_storage: ^10.3.8
 
 dev_dependencies:
   flutter_test:

--- a/test/domain/user/pilgrimage/pilgrimage_repository_test.dart
+++ b/test/domain/user/pilgrimage/pilgrimage_repository_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:logger/logger.dart';
 import 'package:mockito/mockito.dart';
 import 'package:virtualpilgrimage/domain/user/pilgrimage/pilgrimage_repository.dart';
+import 'package:virtualpilgrimage/infrastructure/user/pilgrimage_repository_impl.dart';
 
 import '../../../helper/mock.mocks.dart';
 import '../../../helper/provider_container.dart';
@@ -15,7 +16,7 @@ void main() {
   setUp(() {
     mockFirebaseStorage = MockFirebaseStorage();
     mockReference = MockReference();
-    target = PilgrimageRepository(
+    target = PilgrimageRepositoryImpl(
       mockFirebaseStorage,
       logger,
     );

--- a/test/domain/user/pilgrimage/pilgrimage_repository_test.dart
+++ b/test/domain/user/pilgrimage/pilgrimage_repository_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+import 'package:mockito/mockito.dart';
+import 'package:virtualpilgrimage/domain/user/pilgrimage/pilgrimage_repository.dart';
+
+import '../../../helper/mock.mocks.dart';
+import '../../../helper/provider_container.dart';
+
+void main() {
+  final logger = Logger(level: Level.error);
+  late MockFirebaseStorage mockFirebaseStorage;
+  late MockReference mockReference;
+  late PilgrimageRepository target;
+
+  setUp(() {
+    mockFirebaseStorage = MockFirebaseStorage();
+    mockReference = MockReference();
+    target = PilgrimageRepository(
+      mockFirebaseStorage,
+      logger,
+    );
+  });
+
+  group('PilgrimageRepository', () {
+    test('DI', () {
+      final container = mockedProviderContainer();
+      final repository = container.read(pilgrimageRepositoryProvider);
+      expect(repository, isNotNull);
+    });
+
+    const String pilgrimageId = '1';
+    const String filename = '1.png';
+    group('getTempleImageUrl', () {
+      setUp(() {
+        when(mockFirebaseStorage.ref()).thenReturn(mockReference);
+        when(mockReference.child(any)).thenReturn(mockReference);
+        when(mockReference.getDownloadURL()).thenAnswer((_) => Future.value('http://exmaple.com/temples/$pilgrimageId/$filename'));
+      });
+      group('正常系', () {
+        test('画像URLが出力する', () async {
+          // when
+          final actual = await target.getTempleImageUrl(pilgrimageId, filename);
+
+          // then
+          expect(actual, 'http://exmaple.com/temples/$pilgrimageId/$filename');
+        });
+      });
+    });
+  });
+}

--- a/test/helper/mock.dart
+++ b/test/helper/mock.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:firebase_storage/firebase_storage.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:health/health.dart';
 import 'package:mockito/annotations.dart';
@@ -21,12 +22,14 @@ import 'package:mockito/annotations.dart';
   DocumentSnapshot,
   CollectionReference,
   DocumentReference,
+  Reference,
   Query,
   QuerySnapshot,
 
   /// Others
   FirebaseAnalytics,
   FirebaseCrashlytics,
+  FirebaseStorage,
 
   // ヘルスケア
   HealthFactory,

--- a/test/helper/provider_container.dart
+++ b/test/helper/provider_container.dart
@@ -5,6 +5,7 @@ import 'package:virtualpilgrimage/infrastructure/firebase/firebase_analytics_pro
 import 'package:virtualpilgrimage/infrastructure/firebase/firebase_auth_provider.dart';
 import 'package:virtualpilgrimage/infrastructure/firebase/firebase_crashlytics_provider.dart';
 import 'package:virtualpilgrimage/infrastructure/firebase/firestore_provider.dart';
+import 'package:virtualpilgrimage/infrastructure/firebase/storage_provider.dart';
 
 import 'mock.mocks.dart';
 
@@ -12,6 +13,7 @@ final defaultOverrides = <Override>[
   // firebase
   firebaseAuthProvider.overrideWithValue(MockFirebaseAuth()),
   firestoreProvider.overrideWithValue(MockFirebaseFirestore()),
+  storageProvider.overrideWithValue(MockFirebaseStorage()),
   firebaseAuthUserStateProvider.overrideWithValue(StateController(MockUser())),
   firebaseCrashlyticsProvider.overrideWithValue(MockFirebaseCrashlytics()),
   firebaseAnalyticsProvider.overrideWithValue(MockFirebaseAnalytics()),


### PR DESCRIPTION
## 実装内容

CloudStorageからお寺の情報を表示するように実装しました。
一旦、ボタンを押すとお寺の写真がポップアップで表示するようにしています。（到着した際にポップアップで表示する感じを想定しています）

![](https://i.gyazo.com/d4297f432dae872f59b3413e54a6773e.png)

## 確認事項

- お寺毎にデータを格納する（/temple/{temple_id}/1.jpg）のディレクトリ形式としています。