### PR TITLE
プロフィールページの実装

### DIFF
--- a/lib/analytics.dart
+++ b/lib/analytics.dart
@@ -17,6 +17,7 @@ extension AnalyticsEvent on String {
   static const pressedRegistration = 'pressed_registration';
   static const registrationFailed = 'registration_failed';
   static const initializeHomePageAndGetHealth = 'initialize_home_page_and_get_health';
+  static const pressedUploadImage = 'pressed_upload_image';
 }
 
 final analyticsProvider = Provider<Analytics>(

--- a/lib/domain/user/profile/update_user_profile_image_interactor.dart
+++ b/lib/domain/user/profile/update_user_profile_image_interactor.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+
+import 'package:virtualpilgrimage/domain/customizable_date_time.dart';
+import 'package:virtualpilgrimage/domain/user/profile/update_user_profile_image_usecase.dart';
+import 'package:virtualpilgrimage/domain/user/profile/user_profile_image_repository.dart';
+import 'package:virtualpilgrimage/domain/user/user_repository.dart';
+import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
+
+// ユーザのプロフィール画像を更新するUsecaseの実装
+class UpdateUserProfileImageInteractor extends UpdateUserProfileImageUsecase {
+  UpdateUserProfileImageInteractor(
+    this._userRepository,
+    this._userProfileImageRepository,
+  );
+
+  final UserRepository _userRepository;
+  final UserProfileImageRepository _userProfileImageRepository;
+
+  /// ユーザのプロフィール画像を更新
+  /// 後のstate更新のため、更新したユーザ情報を返す
+  ///
+  /// [user] 更新対象のユーザ
+  /// [imageFile] プロフィール画像を保持したインスタンス
+  @override
+  Future<VirtualPilgrimageUser> execute({
+    required VirtualPilgrimageUser user,
+    required File imageFile,
+  }) async {
+    // 画像をアップロード
+    final profileImageUrl = await _userProfileImageRepository.uploadProfileImage(
+      imageFile: imageFile,
+      userId: user.id,
+    );
+
+    // 最後にFirestoreに保存して state を更新
+    final updatedUser = user.copyWith(
+      userIconUrl: profileImageUrl,
+      updatedAt: CustomizableDateTime.current,
+    );
+    await _userRepository.update(updatedUser);
+
+    return updatedUser;
+  }
+}

--- a/lib/domain/user/profile/update_user_profile_image_usecase.dart
+++ b/lib/domain/user/profile/update_user_profile_image_usecase.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:virtualpilgrimage/domain/user/profile/update_user_profile_image_interactor.dart';
+import 'package:virtualpilgrimage/domain/user/profile/user_profile_image_repository.dart';
+import 'package:virtualpilgrimage/domain/user/user_repository.dart';
+import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
+
+final updateUserProfileImageUsecaseProvider = Provider<UpdateUserProfileImageUsecase>(
+  (ref) => UpdateUserProfileImageInteractor(
+    ref.read(userRepositoryProvider),
+    ref.read(userProfileImageRepositoryProvider),
+  ),
+);
+
+abstract class UpdateUserProfileImageUsecase {
+  /// ユーザのプロフィール画像を更新
+  /// 後のstate更新のため、更新したユーザ情報を返す
+  ///
+  /// [user] 更新対象のユーザ
+  /// [imageFile] プロフィール画像を保持したインスタンス
+  Future<VirtualPilgrimageUser> execute({
+    required VirtualPilgrimageUser user,
+    required File imageFile,
+  });
+}

--- a/lib/domain/user/profile/user_profile_image_repository.dart
+++ b/lib/domain/user/profile/user_profile_image_repository.dart
@@ -1,0 +1,23 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:virtualpilgrimage/infrastructure/firebase/storage_provider.dart';
+import 'package:virtualpilgrimage/infrastructure/user/user_profile_image_repository_impl.dart';
+import 'package:virtualpilgrimage/logger.dart';
+
+final userProfileImageRepositoryProvider = Provider<UserProfileImageRepository>(
+  (ref) => UserProfileImageRepositoryImpl(ref.read(storageProvider), ref.read(loggerProvider)),
+);
+
+abstract class UserProfileImageRepository {
+  /// プロフィール画像をCloudStorageにアップロードしてアップロード先のURLを返す
+  ///
+  /// [imageFile] プロフィール画像にしたいファイル
+  /// [userId] プロフィール画像をアップロードしようとしているユーザのID
+  Future<String> uploadProfileImage({required File imageFile, required String userId});
+
+  /// プロフィール画像のアップロード先のURLを返す
+  ///
+  /// [userId] プロフィール画像のURLを取得したいユーザのID
+  Future<String> getProfileImageUrl({required String userId});
+}

--- a/lib/domain/user/user_icon_repository.dart
+++ b/lib/domain/user/user_icon_repository.dart
@@ -3,8 +3,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:http/http.dart' as http;
 
 final userIconRepositoryProvider = Provider<UserIconRepository>(
-    (ref) => UserIconRepository(
-    ),
+  (ref) => UserIconRepository(),
 );
 
 class UserIconRepository {

--- a/lib/domain/user/virtual_pilgrimage_user.codegen.dart
+++ b/lib/domain/user/virtual_pilgrimage_user.codegen.dart
@@ -10,7 +10,12 @@ import 'package:virtualpilgrimage/domain/user/pilgrimage/pilgrimage_info.codegen
 part 'virtual_pilgrimage_user.codegen.freezed.dart';
 part 'virtual_pilgrimage_user.codegen.g.dart';
 
+// ログインしているユーザの状態
 final userStateProvider = StateProvider<VirtualPilgrimageUser?>((_) => null);
+
+// ユーザのログインステータス
+// ログインステータスによって遷移できるページが変わってくるので、その遷移の為に利用
+final loginStateProvider = StateProvider<UserStatus?>((_) => null);
 
 // 性別
 enum Gender {

--- a/lib/gen/firebase_options_dev.dart
+++ b/lib/gen/firebase_options_dev.dart
@@ -63,6 +63,7 @@ class DefaultFirebaseOptions {
     messagingSenderId: '1048377471641',
     projectId: 'virtual-pilgrimage-dev',
     storageBucket: 'virtual-pilgrimage-dev.appspot.com',
+    androidClientId: '1048377471641-22unossovpppcj49td2k23h0muqhnkcp.apps.googleusercontent.com',
     iosClientId: '1048377471641-pn7ok6oelgf88e9fi803skt5ofhnqp5c.apps.googleusercontent.com',
     iosBundleId: 'com.virtualpilgrimage.dev',
   );

--- a/lib/infrastructure/firebase/cloudstorage_collection_path.dart
+++ b/lib/infrastructure/firebase/cloudstorage_collection_path.dart
@@ -1,0 +1,7 @@
+// CloudStorage の collection のパス定義
+extension CloudStorageCollectionPath on String {
+  static String pilgrimage(String pilgrimageId, String filename) =>
+      'temples/$pilgrimageId/$filename';
+
+  static String user(String userId) => 'users/$userId/profile.png';
+}

--- a/lib/infrastructure/firebase/firebase_auth_provider.dart
+++ b/lib/infrastructure/firebase/firebase_auth_provider.dart
@@ -1,9 +1,8 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-final firebaseAuthProvider =
-    Provider<FirebaseAuth>((_) => FirebaseAuth.instance);
+final firebaseAuthProvider = Provider<FirebaseAuth>((_) => FirebaseAuth.instance);
 
-final firebaseAuthUserStateProvider = StateProvider.autoDispose<User?>(
+final firebaseAuthUserStateProvider = StateProvider<User?>(
   (_) => FirebaseAuth.instance.currentUser,
 );

--- a/lib/infrastructure/user/pilgrimage_repository_impl.dart
+++ b/lib/infrastructure/user/pilgrimage_repository_impl.dart
@@ -1,7 +1,7 @@
-
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:logger/logger.dart';
 import 'package:virtualpilgrimage/domain/user/pilgrimage/pilgrimage_repository.dart';
+import 'package:virtualpilgrimage/infrastructure/firebase/cloudstorage_collection_path.dart';
 
 class PilgrimageRepositoryImpl implements PilgrimageRepository {
   PilgrimageRepositoryImpl(this._firestoreClient, this._logger);
@@ -11,7 +11,9 @@ class PilgrimageRepositoryImpl implements PilgrimageRepository {
 
   @override
   Future<String> getTempleImageUrl(String pilgrimageId, String filename) async {
-    final storageRef = _firestoreClient.ref().child('temples/$pilgrimageId/$filename');
+    final storageRef = _firestoreClient.ref().child(
+          CloudStorageCollectionPath.pilgrimage(pilgrimageId, filename),
+        );
 
     _logger.d(filename);
 

--- a/lib/infrastructure/user/user_profile_image_repository_impl.dart
+++ b/lib/infrastructure/user/user_profile_image_repository_impl.dart
@@ -1,0 +1,45 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:logger/logger.dart';
+import 'package:virtualpilgrimage/domain/user/profile/user_profile_image_repository.dart';
+import 'package:virtualpilgrimage/infrastructure/firebase/cloudstorage_collection_path.dart';
+
+class UserProfileImageRepositoryImpl extends UserProfileImageRepository {
+  UserProfileImageRepositoryImpl(this._firestoreClient, this._logger);
+
+  final FirebaseStorage _firestoreClient;
+  final Logger _logger;
+
+  /// プロフィール画像をCloudStorageにアップロードしてアップロード先のURLを返す
+  ///
+  /// [imageFile] プロフィール画像にしたいファイル
+  /// [userId] プロフィール画像をアップロードしようとしているユーザのID
+  @override
+  Future<String> uploadProfileImage({required File imageFile, required String userId}) async {
+    // 変数に結果を入れない&以下のコメントがないとlinterに怒られるのでignoreコメントを付与
+    // ignore:unused_local_variable
+    final snapshot = _ref(userId).putFile(imageFile);
+    final url = await getProfileImageUrl(userId: userId);
+
+    _logger.d('uploading user profile image success. [userId][$userId][url][$url]');
+
+    return url;
+  }
+
+  /// プロフィール画像のアップロード先のURLを返す
+  ///
+  /// [userId] プロフィール画像のURLを取得したいユーザのID
+  @override
+  Future<String> getProfileImageUrl({required String userId}) async {
+    final ref = _ref(userId);
+    final url = await ref.getDownloadURL();
+    _logger.d('user profile image url [userId][$userId][url][$url]');
+    return url;
+  }
+
+  Reference _ref(String userId) {
+    return _firestoreClient.ref().child(CloudStorageCollectionPath.user(userId));
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,6 +28,7 @@ class _App extends ConsumerWidget {
     final firebaseAuth = ref.watch(firebaseAuthProvider);
     final analytics = ref.read(analyticsProvider);
     final userState = ref.watch(userStateProvider.state);
+    final loginState = ref.watch(loginStateProvider.state);
     final userIconRepository = ref.read(userIconRepositoryProvider);
 
     // Firebaseへのログインがキャッシュされていれば
@@ -40,6 +41,7 @@ class _App extends ConsumerWidget {
           userIconRepository.loadIconImage(value.userIconUrl).then((bitmap) {
             value = value!.copyWith(userIcon: bitmap);
             userState.state = value;
+            loginState.state = value!.userStatus;
           });
         }
       });

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -53,9 +53,10 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>(
           final canEdit = state.queryParams['canEdit'];
           final previousPage = state.queryParams['previousPagePath'];
           return ProfilePage(
-              userId: userId,
-              canEdit: canEdit == 'true',
-              previousPagePath: previousPage ?? RouterPath.home);
+            userId: userId,
+            canEdit: canEdit == 'true',
+            previousPagePath: previousPage ?? RouterPath.home,
+          );
         },
       ),
     ],

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -63,13 +63,13 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>(
     redirect: (state) {
       ref.read(loggerProvider).d(state.location);
       // サインイン状態によって遷移先を変える
-      final userState = ref.watch(userStateProvider);
-      if (userState == null) {
+      final loginState = ref.watch(loginStateProvider);
+      if (loginState == null) {
         if (state.location != RouterPath.signIn) {
           return RouterPath.signIn;
         }
       } else {
-        switch (userState.userStatus) {
+        switch (loginState) {
           // ユーザが作成済みの時
           // 基本的にはここにページ遷移を記載する
           case UserStatus.created:

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -4,7 +4,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
 import 'package:virtualpilgrimage/infrastructure/firebase/firebase_analytics_provider.dart';
+import 'package:virtualpilgrimage/logger.dart';
 import 'package:virtualpilgrimage/ui/pages/home/home_page.dart';
+import 'package:virtualpilgrimage/ui/pages/profile/profile_page.dart';
 import 'package:virtualpilgrimage/ui/pages/registration/registration_page.dart';
 import 'package:virtualpilgrimage/ui/pages/sign_in/sign_in_page.dart';
 
@@ -12,6 +14,7 @@ extension RouterPath on String {
   static const home = '/';
   static const signIn = '/signin';
   static const registration = '/registration';
+  static const profile = '/profile';
 }
 
 // ref. https://zenn.dev/mkikuchi/articles/cc87c84e1404c4
@@ -25,11 +28,7 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>(
       // ルート
       GoRoute(
         path: RouterPath.home,
-        // TODO(s14t284): builder vs pageBuilder でどちらが良いか検討する
-        pageBuilder: (context, state) => MaterialPage<void>(
-          key: state.pageKey,
-          child: HomePage(key: state.pageKey),
-        ),
+        builder: (context, state) => const HomePage(),
       ),
       // ログイン
       GoRoute(
@@ -44,9 +43,24 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>(
         builder: (BuildContext context, GoRouterState state) {
           return const RegistrationPage();
         },
-      )
+      ),
+      // ユーザ情報表示
+      GoRoute(
+        name: RouterPath.profile,
+        path: RouterPath.profile,
+        builder: (BuildContext context, GoRouterState state) {
+          final userId = state.queryParams['userId']!;
+          final canEdit = state.queryParams['canEdit'];
+          final previousPage = state.queryParams['previousPagePath'];
+          return ProfilePage(
+              userId: userId,
+              canEdit: canEdit == 'true',
+              previousPagePath: previousPage ?? RouterPath.home);
+        },
+      ),
     ],
     redirect: (state) {
+      ref.read(loggerProvider).d(state.location);
       // サインイン状態によって遷移先を変える
       final userState = ref.watch(userStateProvider);
       if (userState == null) {
@@ -55,16 +69,17 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>(
         }
       } else {
         switch (userState.userStatus) {
+          // ユーザが作成済みの時
+          // 基本的にはここにページ遷移を記載する
+          case UserStatus.created:
+            return null;
+          // ユーザ情報が登録途中の時
           case UserStatus.temporary:
             if (state.location != RouterPath.registration) {
               return RouterPath.registration;
             }
             break;
-          case UserStatus.created:
-            if (state.location != RouterPath.home) {
-              return RouterPath.home;
-            }
-            break;
+          // 削除済みの時
           case UserStatus.deleted:
             // TODO(s14t284): Handle this case.
             break;

--- a/lib/ui/components/my_app_bar.dart
+++ b/lib/ui/components/my_app_bar.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class MyAppBar extends StatelessWidget with PreferredSizeWidget {
+  const MyAppBar({super.key});
+
+  static const appTitle = '巡礼ウォーク';
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      title: const Text(appTitle),
+      backgroundColor: Theme.of(context).appBarTheme.backgroundColor,
+    );
+  }
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+}

--- a/lib/ui/components/my_app_bar.dart
+++ b/lib/ui/components/my_app_bar.dart
@@ -10,6 +10,7 @@ class MyAppBar extends StatelessWidget with PreferredSizeWidget {
     return AppBar(
       title: const Text(appTitle),
       backgroundColor: Theme.of(context).appBarTheme.backgroundColor,
+      automaticallyImplyLeading: true,
     );
   }
 

--- a/lib/ui/components/profile_icon.dart
+++ b/lib/ui/components/profile_icon.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+// プロフィール画像を表示するWidget
+class ProfileIconWidget extends StatelessWidget {
+  const ProfileIconWidget({
+    super.key,
+    required this.iconUrl,
+    required this.size,
+    this.onTap,
+  });
+
+  final String iconUrl;
+  final double size;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final image = NetworkImage(iconUrl);
+
+    return ClipOval(
+      child: Material(
+        color: Colors.transparent,
+        child: Ink.image(
+          image: image,
+          fit: BoxFit.cover,
+          width: size,
+          height: size,
+          child: InkWell(
+            onTap: onTap,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/home/home_page.dart
+++ b/lib/ui/pages/home/home_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
 import 'package:virtualpilgrimage/router.dart';
+import 'package:virtualpilgrimage/ui/components/my_app_bar.dart';
 import 'package:virtualpilgrimage/ui/pages/home/components/google_map_view.dart';
 import 'package:virtualpilgrimage/ui/pages/sign_in/sign_in_presenter.dart';
 import 'package:virtualpilgrimage/ui/style/color.dart';
@@ -13,10 +14,7 @@ class HomePage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('巡礼ウォーク'),
-        backgroundColor: Theme.of(context).appBarTheme.backgroundColor,
-      ),
+      appBar: const MyAppBar(),
       body: HomePageBody(ref),
     );
   }

--- a/lib/ui/pages/home/home_page.dart
+++ b/lib/ui/pages/home/home_page.dart
@@ -81,6 +81,19 @@ class HomePageBody extends StatelessWidget {
               },
               child: const Text('サインイン画面に戻る'),
             ),
+            ElevatedButton(
+              onPressed: () async {
+                _ref.read(routerProvider).pushNamed(
+                  RouterPath.profile,
+                  queryParams: {
+                    'userId': userState?.id ?? '',
+                    'canEdit': 'true',
+                    'previousPagePath': RouterPath.home,
+                  },
+                );
+              },
+              child: const Text('プロフィールページ'),
+            ),
             const Padding(
               padding: EdgeInsetsDirectional.all(16),
             ),

--- a/lib/ui/pages/profile/components/profile_health_card.dart
+++ b/lib/ui/pages/profile/components/profile_health_card.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:virtualpilgrimage/ui/style/font.dart';
+
+class ProfileHealthCard extends StatelessWidget {
+  const ProfileHealthCard({
+    required this.title,
+    required this.value,
+    required this.unit,
+    required this.backgroundColor,
+    this.textColor = Colors.white,
+    required this.icon,
+    super.key,
+  });
+
+  final String title;
+  final String value;
+  final String unit;
+  final Color backgroundColor;
+  final Color textColor;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Stack(
+        children: [
+          Card(
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+            ),
+            color: backgroundColor,
+            child: Padding(
+              padding: const EdgeInsetsDirectional.all(12),
+              child: Column(
+                children: [
+                  const SizedBox(
+                    height: 12,
+                  ),
+                  Text(
+                    title,
+                    style: TextStyle(
+                      color: textColor,
+                      fontSize: FontStyle.mediumSize,
+                      fontWeight: FontWeight.w300,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(
+                    height: 8,
+                  ),
+                  Text(
+                    value,
+                    style: TextStyle(
+                      color: textColor,
+                      fontSize: FontStyle.largeSize,
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                  Container(
+                    alignment: Alignment.centerRight,
+                    child: Text(
+                      unit,
+                      style: TextStyle(color: textColor, fontWeight: FontWeight.w900),
+                      textAlign: TextAlign.right,
+                    ),
+                  )
+                ],
+              ),
+            ),
+          ),
+          Positioned(
+            top: 8,
+            right: 4,
+            child: Icon(
+              icon,
+              color: Colors.white,
+              size: 28,
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/profile/profile_page.dart
+++ b/lib/ui/pages/profile/profile_page.dart
@@ -98,6 +98,7 @@ class _ProfilePageBody extends StatelessWidget {
         ),
 
         /// ユーザの基礎情報
+        // TODO(s14t284): お遍路の進捗状況も表示する
         _buildProfile(context, user),
       ],
     );

--- a/lib/ui/pages/profile/profile_page.dart
+++ b/lib/ui/pages/profile/profile_page.dart
@@ -30,7 +30,7 @@ class ProfilePage extends ConsumerWidget {
       ref.read(routerProvider).go(RouterPath.signIn);
     }
 
-    final user = ref.watch(profileProvider(userId));
+    final user = ref.watch(profileUserProvider(userId));
     return Scaffold(
       appBar: const MyAppBar(),
       body: SafeArea(
@@ -68,7 +68,7 @@ class _ProfilePageBody extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final notifier = ref.read(profilePresenter.notifier);
+    final notifier = ref.read(profileProvider.notifier);
     return ListView(
       children: [
         const SizedBox(
@@ -116,8 +116,8 @@ class _ProfilePageBody extends StatelessWidget {
       );
 
   Widget _buildProfile(BuildContext context, VirtualPilgrimageUser user) {
-    final notifier = ref.read(profilePresenter.notifier);
-    final state = ref.watch(profilePresenter);
+    final notifier = ref.read(profileProvider.notifier);
+    final state = ref.watch(profileProvider);
     final health = user.health;
     final List<List<ProfileHealthCard>> healthCards = [];
     if (health != null) {

--- a/lib/ui/pages/profile/profile_page.dart
+++ b/lib/ui/pages/profile/profile_page.dart
@@ -1,0 +1,194 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_toggle_tab/flutter_toggle_tab.dart';
+import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
+import 'package:virtualpilgrimage/router.dart';
+import 'package:virtualpilgrimage/ui/components/my_app_bar.dart';
+import 'package:virtualpilgrimage/ui/components/profile_icon.dart';
+import 'package:virtualpilgrimage/ui/pages/profile/components/profile_health_card.dart';
+import 'package:virtualpilgrimage/ui/pages/profile/profile_presenter.dart';
+import 'package:virtualpilgrimage/ui/style/color.dart';
+import 'package:virtualpilgrimage/ui/style/font.dart';
+
+class ProfilePage extends ConsumerWidget {
+  const ProfilePage({
+    required this.userId,
+    required this.canEdit,
+    required this.previousPagePath,
+    super.key,
+  });
+
+  final String userId;
+  final bool canEdit;
+  final String previousPagePath;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final userState = ref.watch(userStateProvider);
+    // ユーザ情報が null の場合、何も描画できないのでログインページに遷移させる
+    if (userState == null) {
+      ref.read(routerProvider).go(RouterPath.signIn);
+    }
+
+    final user = ref.watch(profileProvider(userId));
+    return Scaffold(
+      appBar: const MyAppBar(),
+      body: SafeArea(
+        // TODO(s14t284): loading, error 周りを整理する
+        child: user.when(
+          data: (data) {
+            if (data != null) {
+              return _ProfilePageBody(user: data, canEdit: canEdit, ref: ref);
+            }
+            // TODO(s14t284): 他ユーザの情報を参照できるようになったら　null の場合の UI も実装する
+            return const Text('そのユーザは存在しませんでした');
+          },
+          error: (e, _) {
+            return Text(e.toString());
+          },
+          loading: () {
+            return const Text('読み込み中');
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _ProfilePageBody extends StatelessWidget {
+  const _ProfilePageBody({
+    required this.user,
+    required this.canEdit,
+    required this.ref,
+  });
+
+  final VirtualPilgrimageUser user;
+  final bool canEdit;
+  final WidgetRef ref;
+
+  @override
+  Widget build(BuildContext context) {
+    final notifier = ref.read(profilePresenter.notifier);
+    return ListView(
+      children: [
+        const SizedBox(
+          height: 24,
+        ),
+
+        /// ユーザアイコン
+        Center(
+          child: Stack(
+            children: [
+              ProfileIconWidget(
+                iconUrl: user.userIconUrl,
+                size: 128,
+                onTap: notifier.updateProfileImage,
+              ),
+              if (canEdit)
+                Positioned(
+                  bottom: 0,
+                  right: 4,
+                  child: _buildUserIconEditButton(context),
+                ),
+            ],
+          ),
+        ),
+        const SizedBox(
+          height: 24,
+        ),
+
+        /// ユーザの基礎情報
+        _buildProfile(context, user),
+      ],
+    );
+  }
+
+  Widget _buildUserIconEditButton(BuildContext context) => ClipOval(
+        child: Container(
+          padding: const EdgeInsets.all(8),
+          color: Theme.of(context).primaryColor,
+          child: const Icon(
+            Icons.edit,
+            color: ColorStyle.white,
+            size: 20,
+          ),
+        ),
+      );
+
+  Widget _buildProfile(BuildContext context, VirtualPilgrimageUser user) {
+    final notifier = ref.read(profilePresenter.notifier);
+    final state = ref.watch(profilePresenter);
+    final health = user.health;
+    final List<List<ProfileHealthCard>> healthCards = [];
+    if (health != null) {
+      final healthByPeriod = [health.yesterday, health.week, health.month];
+      for (final h in healthByPeriod) {
+        healthCards.add([
+          ProfileHealthCard(
+            title: '歩数',
+            value: h.steps.toString(),
+            unit: '歩',
+            backgroundColor: Colors.lightGreen,
+            icon: Icons.directions_run_rounded,
+          ),
+          ProfileHealthCard(
+            title: '移動距離',
+            value: h.distance.toString(),
+            unit: 'm',
+            backgroundColor: Colors.lightBlue,
+            icon: Icons.map_outlined,
+          ),
+          ProfileHealthCard(
+            title: '消費カロリー',
+            value: h.burnedCalorie.toString(),
+            unit: 'kcal',
+            backgroundColor: Colors.orangeAccent,
+            icon: Icons.local_fire_department_outlined,
+          ),
+        ]);
+      }
+    }
+    return Column(
+      children: [
+        Text(
+          '${user.nickname} さん',
+          style: const TextStyle(fontWeight: FontWeight.bold, fontSize: FontStyle.largeSize),
+        ),
+        const SizedBox(height: 12),
+        Row(
+          mainAxisSize: MainAxisSize.max,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              '${notifier.getAgeString(user.birthDay)} ${notifier.getGenderString(user.gender)}',
+              style: const TextStyle(
+                fontSize: FontStyle.largeSize,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 24),
+        FlutterToggleTab(
+          width: 60,
+          labels: notifier.tabLabels(),
+          selectedLabelIndex: (index) {
+            notifier.setSelectedTabIndex(index);
+          },
+          selectedTextStyle: const TextStyle(
+            fontWeight: FontWeight.bold,
+          ),
+          unSelectedTextStyle: const TextStyle(
+            color: Colors.black54,
+            fontWeight: FontWeight.w200,
+          ),
+          selectedIndex: state.selectedTabIndex,
+        ),
+        const SizedBox(height: 12),
+        // クラッシュ対策のため、全てのヘルスチェック情報を取得できているときに表示
+        if (healthCards.length == notifier.tabLabels().length)
+          Row(children: healthCards[state.selectedTabIndex]),
+      ],
+    );
+  }
+}

--- a/lib/ui/pages/profile/profile_presenter.dart
+++ b/lib/ui/pages/profile/profile_presenter.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:virtualpilgrimage/domain/user/user_repository.dart';
+import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
+import 'package:virtualpilgrimage/ui/pages/profile/profile_state.codegen.dart';
+
+final profileProvider = FutureProvider.family<VirtualPilgrimageUser?, String>((ref, userId) async {
+  // ログイン状態でしか呼ばれないため、nullable を想定していない
+  final loginUser = ref.read(userStateProvider)!;
+  // ログインユーザ自身を指定していた場合はそのまま返す
+  if (loginUser.id == userId) {
+    return loginUser;
+  }
+  // そうでなければDBに問い合わせ
+  return ref.read(userRepositoryProvider).get(userId);
+});
+
+final profilePresenter = StateNotifierProvider.autoDispose<ProfilePresenter, ProfileState>(
+  (ref) => ProfilePresenter(),
+);
+
+class ProfilePresenter extends StateNotifier<ProfileState> {
+  ProfilePresenter() : super(ProfileState(selectedTabIndex: 0));
+
+  final _selectedTabs = ['昨日', '週間', '月間'];
+  final _genderString = ['性別未設定', '男性', '女性'];
+
+  List<String> tabLabels() => _selectedTabs;
+
+  /// ヘルスケア情報のタブ選択の切り替えを行う
+  Future<void> setSelectedTabIndex(int index) async {
+    state = state.copyWith(selectedTabIndex: index);
+  }
+
+  /// 性別の表示文字列を取得
+  String getGenderString(Gender gender) => _genderString[gender.index];
+
+  /// 年代の表示文字列を取得
+  String getAgeString(DateTime birthday) {
+    // 年齢を導出し、年代に変換して表示文字列を成形
+    // ex. 71歳
+    // floor(71 / 10) * 10 = floor(7.1) * 10 = 7 * 10 = 70
+    // => 70代
+    final age = _calcAge(birthday);
+    return '${(age / 10).floor() * 10}代';
+  }
+
+  /// datetime から年齢を計算するロジック。
+  ///
+  /// ex. 当日: 20221001, 誕生日: 19501201 (71歳)
+  /// floor((20221001 - 19501201)/10000) = floor(719800 / 10000) = floor(71.98) = 71
+  /// FIXME: 流用するならば domain service にロジックを移す
+  int _calcAge(DateTime birthday) {
+    final today = DateTime.now();
+    final todayYYYYMMDD = today.year * 10000 + today.month * 100 + today.day;
+    final birthdayYYYYMDD = birthday.year * 10000 + birthday.month * 100 + birthday.day;
+    return ((todayYYYYMMDD - birthdayYYYYMDD) / 10000).floor();
+  }
+
+  /// プロフィール画像を更新する
+  Future<void> updateProfileImage() async {
+    // TODO(s14t284): cloud storage に画像をアップロードし、firestore のプロフィール画像URLを更新する処理を実装
+  }
+}

--- a/lib/ui/pages/profile/profile_presenter.dart
+++ b/lib/ui/pages/profile/profile_presenter.dart
@@ -1,9 +1,11 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:virtualpilgrimage/domain/customizable_date_time.dart';
 import 'package:virtualpilgrimage/domain/user/user_repository.dart';
 import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
 import 'package:virtualpilgrimage/ui/pages/profile/profile_state.codegen.dart';
 
-final profileProvider = FutureProvider.family<VirtualPilgrimageUser?, String>((ref, userId) async {
+final profileUserProvider =
+    FutureProvider.family<VirtualPilgrimageUser?, String>((ref, userId) async {
   // ログイン状態でしか呼ばれないため、nullable を想定していない
   final loginUser = ref.read(userStateProvider)!;
   // ログインユーザ自身を指定していた場合はそのまま返す
@@ -14,7 +16,7 @@ final profileProvider = FutureProvider.family<VirtualPilgrimageUser?, String>((r
   return ref.read(userRepositoryProvider).get(userId);
 });
 
-final profilePresenter = StateNotifierProvider.autoDispose<ProfilePresenter, ProfileState>(
+final profileProvider = StateNotifierProvider.autoDispose<ProfilePresenter, ProfileState>(
   (ref) => ProfilePresenter(),
 );
 
@@ -22,7 +24,7 @@ class ProfilePresenter extends StateNotifier<ProfileState> {
   ProfilePresenter() : super(ProfileState(selectedTabIndex: 0));
 
   final _selectedTabs = ['昨日', '週間', '月間'];
-  final _genderString = ['性別未設定', '男性', '女性'];
+  final _genderString = ['', '男性', '女性'];
 
   List<String> tabLabels() => _selectedTabs;
 
@@ -50,7 +52,7 @@ class ProfilePresenter extends StateNotifier<ProfileState> {
   /// floor((20221001 - 19501201)/10000) = floor(719800 / 10000) = floor(71.98) = 71
   /// FIXME: 流用するならば domain service にロジックを移す
   int _calcAge(DateTime birthday) {
-    final today = DateTime.now();
+    final today = CustomizableDateTime.current;
     final todayYYYYMMDD = today.year * 10000 + today.month * 100 + today.day;
     final birthdayYYYYMDD = birthday.year * 10000 + birthday.month * 100 + birthday.day;
     return ((todayYYYYMMDD - birthdayYYYYMDD) / 10000).floor();

--- a/lib/ui/pages/profile/profile_state.codegen.dart
+++ b/lib/ui/pages/profile/profile_state.codegen.dart
@@ -1,0 +1,12 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'profile_state.codegen.freezed.dart';
+
+@freezed
+class ProfileState with _$ProfileState {
+  factory ProfileState({
+    required int selectedTabIndex,
+  }) = _ProfileState;
+
+  const ProfileState._();
+}

--- a/lib/ui/pages/profile/profile_state.codegen.freezed.dart
+++ b/lib/ui/pages/profile/profile_state.codegen.freezed.dart
@@ -1,0 +1,132 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'profile_state.codegen.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$ProfileState {
+  int get selectedTabIndex => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ProfileStateCopyWith<ProfileState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ProfileStateCopyWith<$Res> {
+  factory $ProfileStateCopyWith(
+          ProfileState value, $Res Function(ProfileState) then) =
+      _$ProfileStateCopyWithImpl<$Res>;
+  $Res call({int selectedTabIndex});
+}
+
+/// @nodoc
+class _$ProfileStateCopyWithImpl<$Res> implements $ProfileStateCopyWith<$Res> {
+  _$ProfileStateCopyWithImpl(this._value, this._then);
+
+  final ProfileState _value;
+  // ignore: unused_field
+  final $Res Function(ProfileState) _then;
+
+  @override
+  $Res call({
+    Object? selectedTabIndex = freezed,
+  }) {
+    return _then(_value.copyWith(
+      selectedTabIndex: selectedTabIndex == freezed
+          ? _value.selectedTabIndex
+          : selectedTabIndex // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$$_ProfileStateCopyWith<$Res>
+    implements $ProfileStateCopyWith<$Res> {
+  factory _$$_ProfileStateCopyWith(
+          _$_ProfileState value, $Res Function(_$_ProfileState) then) =
+      __$$_ProfileStateCopyWithImpl<$Res>;
+  @override
+  $Res call({int selectedTabIndex});
+}
+
+/// @nodoc
+class __$$_ProfileStateCopyWithImpl<$Res>
+    extends _$ProfileStateCopyWithImpl<$Res>
+    implements _$$_ProfileStateCopyWith<$Res> {
+  __$$_ProfileStateCopyWithImpl(
+      _$_ProfileState _value, $Res Function(_$_ProfileState) _then)
+      : super(_value, (v) => _then(v as _$_ProfileState));
+
+  @override
+  _$_ProfileState get _value => super._value as _$_ProfileState;
+
+  @override
+  $Res call({
+    Object? selectedTabIndex = freezed,
+  }) {
+    return _then(_$_ProfileState(
+      selectedTabIndex: selectedTabIndex == freezed
+          ? _value.selectedTabIndex
+          : selectedTabIndex // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_ProfileState extends _ProfileState {
+  _$_ProfileState({required this.selectedTabIndex}) : super._();
+
+  @override
+  final int selectedTabIndex;
+
+  @override
+  String toString() {
+    return 'ProfileState(selectedTabIndex: $selectedTabIndex)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_ProfileState &&
+            const DeepCollectionEquality()
+                .equals(other.selectedTabIndex, selectedTabIndex));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(selectedTabIndex));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_ProfileStateCopyWith<_$_ProfileState> get copyWith =>
+      __$$_ProfileStateCopyWithImpl<_$_ProfileState>(this, _$identity);
+}
+
+abstract class _ProfileState extends ProfileState {
+  factory _ProfileState({required final int selectedTabIndex}) =
+      _$_ProfileState;
+  _ProfileState._() : super._();
+
+  @override
+  int get selectedTabIndex;
+  @override
+  @JsonKey(ignore: true)
+  _$$_ProfileStateCopyWith<_$_ProfileState> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/ui/pages/registration/registration_page.dart
+++ b/lib/ui/pages/registration/registration_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:virtualpilgrimage/router.dart';
 import 'package:virtualpilgrimage/ui/components/gender_radio_buttons.dart';
+import 'package:virtualpilgrimage/ui/components/my_app_bar.dart';
 import 'package:virtualpilgrimage/ui/components/my_text_form_field.dart';
 import 'package:virtualpilgrimage/ui/pages/registration/registration_presenter.dart';
 import 'package:virtualpilgrimage/ui/pages/sign_in/sign_in_presenter.dart';
@@ -14,10 +15,7 @@ class RegistrationPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('巡礼ウォーク'),
-        backgroundColor: Theme.of(context).appBarTheme.backgroundColor,
-      ),
+      appBar: const MyAppBar(),
       body: RegistrationPageBody(ref),
     );
   }
@@ -55,9 +53,8 @@ class RegistrationPageBody extends StatelessWidget {
                     color: state.nickname.focusNode.hasFocus
                         ? Theme.of(context).primaryColor
                         : ColorStyle.text,
-                    fontWeight: state.nickname.focusNode.hasFocus
-                        ? FontWeight.bold
-                        : FontWeight.normal,
+                    fontWeight:
+                        state.nickname.focusNode.hasFocus ? FontWeight.bold : FontWeight.normal,
                   ),
                   hintText: 'ニックネーム',
                   border: OutlineInputBorder(
@@ -106,11 +103,11 @@ class RegistrationPageBody extends StatelessWidget {
               ),
               Padding(
                 padding: const EdgeInsets.only(
-                top: 32,
-                right: 12,
-                left: 12,
-                bottom: 12,
-              ),
+                  top: 32,
+                  right: 12,
+                  left: 12,
+                  bottom: 12,
+                ),
                 child: Column(),
               ),
               ElevatedButton(

--- a/lib/ui/pages/registration/registration_presenter.dart
+++ b/lib/ui/pages/registration/registration_presenter.dart
@@ -114,11 +114,11 @@ class RegistrationPresenter extends StateNotifier<RegistrationState> {
       // ユーザ登録に成功したらユーザの state を更新
       case RegistrationResultStatus.success:
         _ref.read(userStateProvider.state).state = updatedUser;
+        _ref.read(loginStateProvider.state).state = updatedUser.userStatus;
         break;
       case RegistrationResultStatus.alreadyExistSameNicknameUser:
         state = state.copyWith(
-          nickname:
-              state.nickname.addExternalError('既に使われているため別のニックネームにしてください'),
+          nickname: state.nickname.addExternalError('既に使われているため別のニックネームにしてください'),
         );
         unawaited(
           _analytics.logEvent(

--- a/lib/ui/pages/sign_in/sign_in_page.dart
+++ b/lib/ui/pages/sign_in/sign_in_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_signin_button/flutter_signin_button.dart';
 import 'package:virtualpilgrimage/model/form_model.codegen.dart';
+import 'package:virtualpilgrimage/ui/components/my_app_bar.dart';
 import 'package:virtualpilgrimage/ui/components/my_text_form_field.dart';
 import 'package:virtualpilgrimage/ui/pages/sign_in/sign_in_presenter.dart';
 import 'package:virtualpilgrimage/ui/style/color.dart';
@@ -13,10 +14,7 @@ class SignInPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('巡礼ウォーク'),
-        backgroundColor: Theme.of(context).appBarTheme.backgroundColor,
-      ),
+      appBar: const MyAppBar(),
       body: SignInPageBody(ref),
     );
   }

--- a/lib/ui/style/font.dart
+++ b/lib/ui/style/font.dart
@@ -1,3 +1,4 @@
 mixin FontStyle {
   static const double mediumSize = 16;
+  static const double largeSize = 24;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -176,6 +176,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.2"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.3+2"
   crypto:
     dependency: transitive
     description:
@@ -585,6 +592,41 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.2.0"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.8.5+3"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.8.5+3"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.10"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.8.6+1"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.6.2"
   intl:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -419,6 +419,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_toggle_tab:
+    dependency: "direct main"
+    description:
+      name: flutter_toggle_tab
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,7 @@ dependencies:
       ref: master
   google_maps_flutter: ^2.2.0
   google_polyline_algorithm: ^3.1.0
+  flutter_toggle_tab: ^1.2.0
   # health
   health: ^4.1.1
   permission_handler: ^9.2.0 # Firebaseと同じSDKをターゲットにできるよう最新ではないバージョンを利用

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   json_annotation: ^4.6.0
   intl: ^0.17.0
   http: ^0.13.5
+  image_picker: ^0.8.5+3
   # ui
   flutter_datetime_picker:
     # pub.dev からダウンロードできるバージョンだと warn ログが出るので最新バージョンを利用

--- a/test/domain/auth/sign_in_interactor_test.dart
+++ b/test/domain/auth/sign_in_interactor_test.dart
@@ -72,7 +72,7 @@ void main() {
 
   group('SignInInteractor', () {
     CustomizableDateTime.customTime = DateTime.now();
-    
+
     test('DI', () {
       final container = mockedProviderContainer();
       final usecase = container.read(signInUsecaseProvider);
@@ -86,7 +86,8 @@ void main() {
         when(mockUser.displayName).thenReturn('dummyName');
         when(mockUser.photoURL).thenReturn('http://example.com');
         when(mockUserCredential.user).thenReturn(mockUser);
-        when(mockUserIconRepository.loadIconImage('')).thenAnswer((_) async => Future.value(BitmapDescriptor.defaultMarker));
+        when(mockUserIconRepository.loadIconImage(''))
+            .thenAnswer((_) async => Future.value(BitmapDescriptor.defaultMarker));
         when(mockGoogleAuthRepository.signIn()).thenAnswer((_) => Future.value(mockUserCredential));
         defaultMockSignInWithCredentialUser(mockUserRepository, mockFirebaseCrashlytics, userId);
       });
@@ -110,7 +111,8 @@ void main() {
         test('ユーザが存在しないため、作成してサインインできる', () async {
           // given
           when(mockUserRepository.get(userId)).thenAnswer((_) => Future.value(null));
-          when(mockUserIconRepository.loadIconImage('http://example.com')).thenAnswer((_) async => Future.value(BitmapDescriptor.defaultMarker));
+          when(mockUserIconRepository.loadIconImage('http://example.com'))
+              .thenAnswer((_) async => Future.value(BitmapDescriptor.defaultMarker));
 
           final expected = defaultUser(id: userId).copyWith(
             nickname: '',
@@ -207,7 +209,8 @@ void main() {
       const password = 'Passw0rd123';
       group('正常系', () {
         setUp(() {
-          when(mockUserIconRepository.loadIconImage('')).thenAnswer((_) async => Future.value(BitmapDescriptor.defaultMarker));
+          when(mockUserIconRepository.loadIconImage(''))
+              .thenAnswer((_) async => Future.value(BitmapDescriptor.defaultMarker));
         });
 
         test('ユーザが既に存在し、サインインできる', () async {
@@ -269,7 +272,7 @@ void main() {
     group('logout', () {
       test('正常系', () async {
         // given
-        when(mockFirebaseAuth.signOut()).thenAnswer((realInvocation) => Future.value());
+        when(mockFirebaseAuth.signOut()).thenAnswer((_) => Future.value());
 
         // when
         await target.logout();
@@ -313,7 +316,7 @@ void defaultMockSignInWithEmailAndPassword(
   when(mockUser.photoURL).thenReturn('http://example.com');
   when(mockUserCredential.user).thenReturn(mockUser);
   when(mockEmailAndPasswordAuthRepository.signIn(email: email, password: password))
-      .thenAnswer((realInvocation) => Future.value(mockUserCredential));
+      .thenAnswer((_) => Future.value(mockUserCredential));
   defaultMockSignInWithCredentialUser(mockUserRepository, mockFirebaseCrashlytics, userId);
 }
 

--- a/test/domain/user/profile/update_user_profile_image_interactor_test.dart
+++ b/test/domain/user/profile/update_user_profile_image_interactor_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:virtualpilgrimage/domain/customizable_date_time.dart';
+import 'package:virtualpilgrimage/domain/user/profile/update_user_profile_image_interactor.dart';
+import 'package:virtualpilgrimage/domain/user/profile/update_user_profile_image_usecase.dart';
+import 'package:virtualpilgrimage/domain/user/profile/user_profile_image_repository.dart';
+import 'package:virtualpilgrimage/domain/user/user_repository.dart';
+import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
+
+import '../../../helper/mock.mocks.dart';
+import '../../../helper/provider_container.dart';
+import 'update_user_profile_image_interactor_test.mocks.dart';
+
+@GenerateMocks([UserRepository, UserProfileImageRepository])
+void main() {
+  late UpdateUserProfileImageInteractor target;
+  late UserRepository userRepository;
+  late UserProfileImageRepository userProfileImageRepository;
+
+  setUp(() {
+    userRepository = MockUserRepository();
+    userProfileImageRepository = MockUserProfileImageRepository();
+    target = UpdateUserProfileImageInteractor(userRepository, userProfileImageRepository);
+  });
+
+  group('UpdateUserProfileImageInteractor', () {
+    test('DI', () {
+      final container = mockedProviderContainer();
+      final actual = container.read(updateUserProfileImageUsecaseProvider);
+      expect(actual, isNotNull);
+    });
+
+    group('execute', () {
+      setUp(() {
+        CustomizableDateTime.customTime = DateTime.now();
+      });
+      test('正常系', () async {
+        // given
+        final user = VirtualPilgrimageUser(
+          id: 'dummyId',
+          userIconUrl: 'https://profile.png',
+          // URLが書き変わることを確認するため、他の値を入れている
+          birthDay: DateTime(1990, 1, 1),
+          createdAt: DateTime(2022, 10, 10),
+          updatedAt: DateTime(2022, 10, 10),
+        );
+        final expected = user.copyWith(
+          userIconUrl: 'https://dummy.png',
+          updatedAt: CustomizableDateTime.current,
+        );
+        final imageFile = MockFile();
+        when(userProfileImageRepository.uploadProfileImage(imageFile: imageFile, userId: 'dummyId'))
+            .thenAnswer((_) => Future.value('https://dummy.png'));
+        when(userRepository.update(expected)).thenAnswer((_) => Future.value());
+
+        // when
+        final actual = await target.execute(user: user, imageFile: imageFile);
+
+        // then
+        expect(actual, expected);
+        verify(
+          userProfileImageRepository.uploadProfileImage(imageFile: imageFile, userId: 'dummyId'),
+        ).called(1);
+        verify(userRepository.update(expected)).called(1);
+      });
+    });
+  });
+}

--- a/test/domain/user/user_icon_repository_test.dart
+++ b/test/domain/user/user_icon_repository_test.dart
@@ -2,11 +2,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
-import 'package:mockito/annotations.dart';
 import 'package:virtualpilgrimage/domain/user/user_icon_repository.dart';
+
 import '../../helper/provider_container.dart';
 
-@GenerateMocks([http.Client])
 void main() {
   late UserIconRepository target;
 
@@ -26,8 +25,8 @@ void main() {
 
       group('正常系', () {
         setUp(() {
-          MockClient((_) async =>
-            http.Response('assets', 200),
+          MockClient(
+            (_) async => http.Response('assets', 200),
           );
         });
         test('画像が取得できる', () async {

--- a/test/helper/fake_user_repository.dart
+++ b/test/helper/fake_user_repository.dart
@@ -1,0 +1,24 @@
+import 'package:virtualpilgrimage/domain/user/user_repository.dart';
+import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
+
+/// テストで利用する UserRepository の Fake
+class FakeUserRepository implements UserRepository {
+  FakeUserRepository(this.user);
+
+  final VirtualPilgrimageUser user;
+
+  @override
+  Future<VirtualPilgrimageUser?> findWithNickname(String nickname) {
+    return Future.value(user);
+  }
+
+  @override
+  Future<VirtualPilgrimageUser?> get(String userId) {
+    return Future.value(user);
+  }
+
+  @override
+  Future<void> update(VirtualPilgrimageUser user) {
+    return Future.value();
+  }
+}

--- a/test/helper/mock.dart
+++ b/test/helper/mock.dart
@@ -7,6 +7,7 @@ import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:health/health.dart';
+import 'package:http/http.dart' as http;
 import 'package:mockito/annotations.dart';
 
 @GenerateMocks([
@@ -42,5 +43,6 @@ import 'package:mockito/annotations.dart';
 
   // Others
   File,
+  http.Client,
 ])
 void main() {}

--- a/test/helper/mock.dart
+++ b/test/helper/mock.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -26,12 +28,19 @@ import 'package:mockito/annotations.dart';
   Query,
   QuerySnapshot,
 
+  /// Firebase Storage
+  FirebaseStorage,
+  UploadTask,
+  TaskSnapshot,
+
   /// Others
   FirebaseAnalytics,
   FirebaseCrashlytics,
-  FirebaseStorage,
 
   // ヘルスケア
   HealthFactory,
+
+  // Others
+  File,
 ])
 void main() {}

--- a/test/infrastructure/user/user_profile_image_repostitory_impl_test.dart
+++ b/test/infrastructure/user/user_profile_image_repostitory_impl_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+import 'package:mockito/mockito.dart';
+import 'package:virtualpilgrimage/domain/user/profile/user_profile_image_repository.dart';
+import 'package:virtualpilgrimage/infrastructure/user/user_profile_image_repository_impl.dart';
+
+import '../../helper/mock.mocks.dart';
+import '../../helper/provider_container.dart';
+
+void main() {
+  late UserProfileImageRepositoryImpl target;
+  late MockFirebaseStorage storage;
+  final logger = Logger(level: Level.nothing);
+
+  final mockStorageRef = MockReference();
+  final mockProfileImageStorageRef = MockReference();
+  final mockUploadTask = MockUploadTask();
+
+  setUp(() {
+    storage = MockFirebaseStorage();
+    target = UserProfileImageRepositoryImpl(storage, logger);
+  });
+
+  group('UserProfileImageRepositoryImpl', () {
+    test('DI', () {
+      final container = mockedProviderContainer();
+      final actual = container.read(userProfileImageRepositoryProvider);
+      expect(actual, isNotNull);
+    });
+
+    group('uploadProfileImage', () {
+      final imageFile = MockFile();
+      const userId = 'dummyId';
+      const profileImageUrl = 'https://dummy.png';
+      test('正常系', () async {
+        // given
+        when(mockProfileImageStorageRef.putFile(imageFile)).thenAnswer((_) => mockUploadTask);
+        when(mockProfileImageStorageRef.getDownloadURL())
+            .thenAnswer((_) => Future.value(profileImageUrl));
+        when(mockStorageRef.child('users/dummyId/profile.png'))
+            .thenReturn(mockProfileImageStorageRef);
+        when(storage.ref()).thenReturn(mockStorageRef);
+
+        // when
+        final actual = await target.uploadProfileImage(imageFile: imageFile, userId: userId);
+
+        // then
+        expect(actual, profileImageUrl);
+        verify(mockProfileImageStorageRef.putFile(imageFile)).called(1);
+        verify(mockProfileImageStorageRef.getDownloadURL()).called(1);
+      });
+    });
+
+    group('getProfileImageUrl', () {
+      const profileImageUrl = 'https://dummy.png';
+      test('正常系', () async {
+        // given
+        when(mockProfileImageStorageRef.getDownloadURL())
+            .thenAnswer((_) => Future.value(profileImageUrl));
+        when(mockStorageRef.child('users/dummyId/profile.png'))
+            .thenReturn(mockProfileImageStorageRef);
+        when(storage.ref()).thenReturn(mockStorageRef);
+
+        // when
+        final actual = await target.getProfileImageUrl(userId: 'dummyId');
+
+        // then
+        expect(actual, profileImageUrl);
+        verify(mockProfileImageStorageRef.getDownloadURL()).called(1);
+      });
+    });
+  });
+}

--- a/test/ui/pages/home/home_presenter_test.dart
+++ b/test/ui/pages/home/home_presenter_test.dart
@@ -11,7 +11,7 @@ void main() {
     target = container.read(homeProvider.notifier);
   });
 
-  group('RegistrationPresenter', () {
+  group('HomePresenter', () {
     test('DI', () {
       expect(target, isNotNull);
     });

--- a/test/ui/pages/profile/profile_presenter_test.dart
+++ b/test/ui/pages/profile/profile_presenter_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:virtualpilgrimage/domain/customizable_date_time.dart';
+import 'package:virtualpilgrimage/domain/user/user_repository.dart';
+import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
+import 'package:virtualpilgrimage/ui/pages/profile/profile_presenter.dart';
+import 'package:virtualpilgrimage/ui/pages/profile/profile_state.codegen.dart';
+
+import '../../../helper/fake_user_repository.dart';
+import '../../../helper/provider_container.dart';
+
+void main() {
+  late ProfilePresenter target;
+  late UserRepository userRepository;
+  const id = 'dummyId';
+  late VirtualPilgrimageUser user;
+
+  setUp(() {
+    final container = mockedProviderContainer();
+    target = container.read(profileProvider.notifier);
+
+    CustomizableDateTime.customTime = DateTime.now();
+    user = VirtualPilgrimageUser(
+      id: id,
+      birthDay: CustomizableDateTime.current,
+      createdAt: CustomizableDateTime.current,
+      updatedAt: CustomizableDateTime.current,
+    );
+    userRepository = FakeUserRepository(user);
+  });
+
+  group('profileUserProvider', () {
+    late ProviderContainer container;
+    final loginUser = VirtualPilgrimageUser(
+      id: 'dummyLoginUserId',
+      birthDay: CustomizableDateTime.current,
+      createdAt: CustomizableDateTime.current,
+      updatedAt: CustomizableDateTime.current,
+    );
+    setUp(() {
+      container = mockedProviderContainer(
+        overrides: [userRepositoryProvider.overrideWithValue(userRepository)],
+      );
+      container.read(userStateProvider.notifier).state = loginUser;
+    });
+
+    test('ログインユーザと同じユーザを取得する場合', () async {
+      final actualLoading = container.read(profileUserProvider('dummyLoginUserId'));
+      expect(actualLoading, const AsyncValue<VirtualPilgrimageUser?>.loading());
+
+      await Future<void>.value();
+
+      final actualValue = container.read(profileUserProvider('dummyLoginUserId')).value;
+      expect(actualValue, loginUser);
+    });
+
+    test('ログインユーザと違うユーザを取得', () async {
+      final expected = VirtualPilgrimageUser(
+        id: 'dummyId',
+        birthDay: CustomizableDateTime.current,
+        createdAt: CustomizableDateTime.current,
+        updatedAt: CustomizableDateTime.current,
+      );
+
+      final actualLoading = container.read(profileUserProvider('dummyId'));
+      expect(actualLoading, const AsyncValue<VirtualPilgrimageUser?>.loading());
+
+      await Future<void>.value();
+
+      final actualValue = container.read(profileUserProvider('dummyId')).value;
+      expect(actualValue, expected);
+    });
+  });
+
+  group('ProfilePresenter', () {
+    test('DI', () {
+      expect(target, isNotNull);
+    });
+
+    test('tabLabels', () {
+      expect(target.tabLabels(), ['昨日', '週間', '月間']);
+    });
+
+    test('setSelectedTabIndex', () async {
+      const index = 1;
+      await target.setSelectedTabIndex(index);
+      expect(target.debugState, ProfileState(selectedTabIndex: index));
+    });
+
+    test('getGenderString', () {
+      expect(target.getGenderString(Gender.values[0]), '');
+      expect(target.getGenderString(Gender.values[1]), '男性');
+      expect(target.getGenderString(Gender.values[2]), '女性');
+    });
+
+    group('getAgeString', () {
+      setUp(() {
+        CustomizableDateTime.customTime = DateTime(2022, 1, 1);
+      });
+
+      test('22歳 -> 20代', () {
+        expect(target.getAgeString(DateTime(2000, 1, 1)), '20代');
+      });
+
+      test('あと少しで30歳 -> 20代, 1日後に日付を参照して30代', () {
+        final birthday = DateTime(1992, 1, 2, 23, 59, 59, 999, 999);
+        expect(target.getAgeString(birthday), '20代');
+        CustomizableDateTime.customTime = DateTime(2022, 1, 2);
+        expect(target.getAgeString(birthday), '30代');
+      });
+    });
+
+    group('updateProfileImage', () {
+      test('正常系', () async {
+        // FIXME: 必要に応じてテストを書く
+        await target.updateProfileImage();
+      });
+    });
+  });
+}

--- a/test/ui/pages/profile/profile_presenter_test.dart
+++ b/test/ui/pages/profile/profile_presenter_test.dart
@@ -113,7 +113,6 @@ void main() {
     group('updateProfileImage', () {
       test('正常系', () async {
         // FIXME: 必要に応じてテストを書く
-        await target.updateProfileImage();
       });
     });
   });


### PR DESCRIPTION
@itomizu 
プロフィールを表示するページを仮実装しました。
「R」と馬鹿でかく映っているのはユーザのアイコン画像で、Google ログインした場合はデフォルトで名前の先頭文字が入ります。 このページからプロフィールを編集するページに遷移することを想定しています。

「昨日」などのタブを押すと表示する歩数情報なども変化するようにしています。
最終的にはお遍路の情報も表示できればと思っています。(これはお遍路の進捗に関するビジネスロジックを組んでから実装したいと思います)

ref. #17 

<img width="360" alt="image" src="https://user-images.githubusercontent.com/20528138/193461578-f6355d15-355f-4f84-bbfa-c122ec8e614b.png"><img width="360" alt="image" src="https://user-images.githubusercontent.com/20528138/193461672-b5eaf0e9-3331-407d-a0a5-0e4d61925f76.png"><img width="360" alt="image" src="https://user-images.githubusercontent.com/20528138/193461674-fba56603-7ffc-4b5e-be60-b4ed15bd4168.png">

