### PR TITLE
ボトムナビゲーションバーの実装

### DIFF
--- a/lib/domain/user/pilgrimage/pilgrimage_info.codegen.dart
+++ b/lib/domain/user/pilgrimage/pilgrimage_info.codegen.dart
@@ -7,7 +7,7 @@ part 'pilgrimage_info.codegen.g.dart';
 class PilgrimageInfo with _$PilgrimageInfo {
   @JsonSerializable(explicitToJson: true)
   const factory PilgrimageInfo({
-    required int id,
+    required String id,
     required int nowPilgrimageId,
     required int lap,
 }) = _PilgrimageInfo;

--- a/lib/domain/user/pilgrimage/pilgrimage_info.codegen.freezed.dart
+++ b/lib/domain/user/pilgrimage/pilgrimage_info.codegen.freezed.dart
@@ -20,7 +20,7 @@ PilgrimageInfo _$PilgrimageInfoFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$PilgrimageInfo {
-  int get id => throw _privateConstructorUsedError;
+  String get id => throw _privateConstructorUsedError;
   int get nowPilgrimageId => throw _privateConstructorUsedError;
   int get lap => throw _privateConstructorUsedError;
 
@@ -35,7 +35,7 @@ abstract class $PilgrimageInfoCopyWith<$Res> {
   factory $PilgrimageInfoCopyWith(
           PilgrimageInfo value, $Res Function(PilgrimageInfo) then) =
       _$PilgrimageInfoCopyWithImpl<$Res>;
-  $Res call({int id, int nowPilgrimageId, int lap});
+  $Res call({String id, int nowPilgrimageId, int lap});
 }
 
 /// @nodoc
@@ -57,7 +57,7 @@ class _$PilgrimageInfoCopyWithImpl<$Res>
       id: id == freezed
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
-              as int,
+              as String,
       nowPilgrimageId: nowPilgrimageId == freezed
           ? _value.nowPilgrimageId
           : nowPilgrimageId // ignore: cast_nullable_to_non_nullable
@@ -77,7 +77,7 @@ abstract class _$$_PilgrimageInfoCopyWith<$Res>
           _$_PilgrimageInfo value, $Res Function(_$_PilgrimageInfo) then) =
       __$$_PilgrimageInfoCopyWithImpl<$Res>;
   @override
-  $Res call({int id, int nowPilgrimageId, int lap});
+  $Res call({String id, int nowPilgrimageId, int lap});
 }
 
 /// @nodoc
@@ -101,7 +101,7 @@ class __$$_PilgrimageInfoCopyWithImpl<$Res>
       id: id == freezed
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
-              as int,
+              as String,
       nowPilgrimageId: nowPilgrimageId == freezed
           ? _value.nowPilgrimageId
           : nowPilgrimageId // ignore: cast_nullable_to_non_nullable
@@ -126,7 +126,7 @@ class _$_PilgrimageInfo extends _PilgrimageInfo {
       _$$_PilgrimageInfoFromJson(json);
 
   @override
-  final int id;
+  final String id;
   @override
   final int nowPilgrimageId;
   @override
@@ -171,7 +171,7 @@ class _$_PilgrimageInfo extends _PilgrimageInfo {
 
 abstract class _PilgrimageInfo extends PilgrimageInfo {
   const factory _PilgrimageInfo(
-      {required final int id,
+      {required final String id,
       required final int nowPilgrimageId,
       required final int lap}) = _$_PilgrimageInfo;
   const _PilgrimageInfo._() : super._();
@@ -180,7 +180,7 @@ abstract class _PilgrimageInfo extends PilgrimageInfo {
       _$_PilgrimageInfo.fromJson;
 
   @override
-  int get id;
+  String get id;
   @override
   int get nowPilgrimageId;
   @override

--- a/lib/domain/user/pilgrimage/pilgrimage_info.codegen.g.dart
+++ b/lib/domain/user/pilgrimage/pilgrimage_info.codegen.g.dart
@@ -8,7 +8,7 @@ part of 'pilgrimage_info.codegen.dart';
 
 _$_PilgrimageInfo _$$_PilgrimageInfoFromJson(Map<String, dynamic> json) =>
     _$_PilgrimageInfo(
-      id: json['id'] as int,
+      id: json['id'] as String,
       nowPilgrimageId: json['nowPilgrimageId'] as int,
       lap: json['lap'] as int,
     );

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -17,6 +17,15 @@ extension RouterPath on String {
   static const profile = '/profile';
 }
 
+// アニメーション抜きで即ページ遷移させるための設定
+// タブで移動できるページに実装
+CustomTransitionPage<ConsumerWidget> zeroTransitionPage(Widget child, BuildContext context) =>
+    CustomTransitionPage(
+      child: child,
+      transitionDuration: Duration.zero,
+      transitionsBuilder: (context, animation, secondaryAnimation, child) => child,
+    );
+
 // ref. https://zenn.dev/mkikuchi/articles/cc87c84e1404c4
 final Provider<GoRouter> routerProvider = Provider<GoRouter>(
   (ref) => GoRouter(
@@ -28,7 +37,7 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>(
       // ルート
       GoRoute(
         path: RouterPath.home,
-        builder: (context, state) => const HomePage(),
+        pageBuilder: (context, state) => zeroTransitionPage(const HomePage(), context),
       ),
       // ログイン
       GoRoute(
@@ -48,15 +57,16 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>(
       GoRoute(
         name: RouterPath.profile,
         path: RouterPath.profile,
-        builder: (BuildContext context, GoRouterState state) {
+        pageBuilder: (context, state) {
           final userId = state.queryParams['userId']!;
           final canEdit = state.queryParams['canEdit'];
           final previousPage = state.queryParams['previousPagePath'];
-          return ProfilePage(
+          final page = ProfilePage(
             userId: userId,
             canEdit: canEdit == 'true',
             previousPagePath: previousPage ?? RouterPath.home,
           );
+          return zeroTransitionPage(page, context);
         },
       ),
     ],

--- a/lib/ui/components/bottom_navigation.dart
+++ b/lib/ui/components/bottom_navigation.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
+import 'package:virtualpilgrimage/router.dart';
+
+final pageTypeProvider = StateProvider<PageType>((_) => PageType.home);
+
+enum PageType {
+  home,
+  profile,
+  // ranking,
+}
+
+class BottomNavigation extends StatelessWidget {
+  const BottomNavigation(this._ref, {super.key});
+
+  final WidgetRef _ref;
+
+  @override
+  Widget build(BuildContext context) {
+    final userState = _ref.watch(userStateProvider);
+    final pageType = _ref.watch(pageTypeProvider);
+    final pageTypeNotifier = _ref.read(pageTypeProvider.notifier);
+    final router = _ref.read(routerProvider);
+
+    final destinations = <Widget>[
+      NavigationDestination(
+        icon: const Icon(Icons.map_rounded),
+        label: PageType.home.name,
+      ),
+      NavigationDestination(
+        icon: const Icon(Icons.account_circle),
+        label: PageType.profile.name,
+      ),
+      // 下記はランキングページ用の設定
+      // NavigationDestination(icon: const Icon(Icons.emoji_events_outlined), label: ''),
+    ];
+    return NavigationBar(
+      selectedIndex: pageType.index,
+      destinations: destinations,
+      backgroundColor: Colors.white10,
+      onDestinationSelected: (int index) {
+        final pageType = PageType.values[index];
+        pageTypeNotifier.state = pageType;
+        switch (pageType) {
+          case PageType.home:
+            router.go(RouterPath.home);
+            break;
+          case PageType.profile:
+            // ボトムナビゲーションから遷移する場合はログインユーザのプロフィールを表示
+            router.goNamed(
+              RouterPath.profile,
+              queryParams: {
+                'userId': userState?.id ?? '',
+                'canEdit': 'true',
+                'previousPagePath': RouterPath.home,
+              },
+            );
+            break;
+        }
+      },
+    );
+  }
+}

--- a/lib/ui/components/bottom_navigation.dart
+++ b/lib/ui/components/bottom_navigation.dart
@@ -25,11 +25,11 @@ class BottomNavigation extends StatelessWidget {
 
     final destinations = <Widget>[
       NavigationDestination(
-        icon: const Icon(Icons.map_rounded),
+        icon: const Icon(Icons.map_outlined),
         label: PageType.home.name,
       ),
       NavigationDestination(
-        icon: const Icon(Icons.account_circle),
+        icon: const Icon(Icons.account_circle_outlined),
         label: PageType.profile.name,
       ),
       // 下記はランキングページ用の設定
@@ -38,7 +38,7 @@ class BottomNavigation extends StatelessWidget {
     return NavigationBar(
       selectedIndex: pageType.index,
       destinations: destinations,
-      backgroundColor: Colors.white10,
+      backgroundColor: Colors.white70,
       onDestinationSelected: (int index) {
         final pageType = PageType.values[index];
         pageTypeNotifier.state = pageType;

--- a/lib/ui/components/my_app_bar.dart
+++ b/lib/ui/components/my_app_bar.dart
@@ -9,8 +9,6 @@ class MyAppBar extends StatelessWidget with PreferredSizeWidget {
   Widget build(BuildContext context) {
     return AppBar(
       title: const Text(appTitle),
-      backgroundColor: Theme.of(context).appBarTheme.backgroundColor,
-      automaticallyImplyLeading: true,
     );
   }
 

--- a/lib/ui/pages/home/home_page.dart
+++ b/lib/ui/pages/home/home_page.dart
@@ -1,14 +1,14 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intl/intl.dart';
 import 'package:virtualpilgrimage/domain/temple/temple_repository.dart';
 import 'package:virtualpilgrimage/domain/user/pilgrimage/pilgrimage_repository.dart';
 import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
 import 'package:virtualpilgrimage/router.dart';
+import 'package:virtualpilgrimage/ui/components/bottom_navigation.dart';
 import 'package:virtualpilgrimage/ui/components/my_app_bar.dart';
 import 'package:virtualpilgrimage/ui/pages/home/components/google_map_view.dart';
 import 'package:virtualpilgrimage/ui/pages/sign_in/sign_in_presenter.dart';
-import 'package:virtualpilgrimage/ui/style/color.dart';
 
 class HomePage extends ConsumerWidget {
   const HomePage({super.key});
@@ -18,6 +18,7 @@ class HomePage extends ConsumerWidget {
     return Scaffold(
       appBar: const MyAppBar(),
       body: HomePageBody(ref),
+      bottomNavigationBar: BottomNavigation(ref),
     );
   }
 }
@@ -36,96 +37,47 @@ class HomePageBody extends StatelessWidget {
       child: SafeArea(
         child: ListView(
           children: [
-            const Text(
-              'ホームページ',
-              style: TextStyle(
-                fontSize: 64,
-                color: ColorStyle.primary,
-              ),
-            ),
-            Column(
-              children: [
-                Text(
-                  'nickname: ${userState?.nickname ?? ''}',
-                  style: const TextStyle(
-                    fontSize: 24,
-                    color: ColorStyle.grey,
-                  ),
-                ),
-                Text(
-                  'email: ${userState?.email ?? ''}',
-                  style: const TextStyle(
-                    fontSize: 24,
-                    color: ColorStyle.grey,
-                  ),
-                ),
-                Text(
-                  'gender: ${userState?.gender ?? ''}',
-                  style: const TextStyle(
-                    fontSize: 24,
-                    color: ColorStyle.grey,
-                  ),
-                ),
-                Text(
-                  'birthday: ${userState != null ? DateFormat('yyyy/MM/dd').format(userState.birthDay) : ''}',
-                  style: const TextStyle(
-                    fontSize: 24,
-                    color: ColorStyle.grey,
-                  ),
-                ),
-              ],
-            ),
-            ElevatedButton(
-              onPressed: () async {
-                await _ref.read(signInPresenterProvider.notifier).logout();
-                _ref.read(routerProvider).go(RouterPath.signIn);
-              },
-              child: const Text('サインイン画面に戻る'),
-            ),
-            ElevatedButton(
-              onPressed: () async {
-                _ref.read(routerProvider).pushNamed(
-                  RouterPath.profile,
-                  queryParams: {
-                    'userId': userState?.id ?? '',
-                    'canEdit': 'true',
-                    'previousPagePath': RouterPath.home,
-                  },
-                );
-              },
-              child: const Text('プロフィールページ'),
-            ),
-            const Padding(
-              padding: EdgeInsetsDirectional.all(16),
-            ),
-            ElevatedButton(
-              onPressed: () async {
-                final pilgrimage = _ref.watch(pilgrimageRepositoryProvider);
-                final url = await pilgrimage.getTempleImageUrl(
-                  userState?.pilgrimage?.nowPilgrimageId.toString() ?? '1',
-                  '1.jpg',
-                );
-                final temple = _ref.watch(templeRepositoryProvider);
-                final templeInfo = await temple.getTempleInfo(1);
-                await showDialog<void>(
-                  context: context,
-                  builder: (BuildContext context) {
-                    return AlertDialog(
-                      title: Text(templeInfo.prefecture),
-                      content: Image.network(url),
-                      actions: <Widget>[
-                        ElevatedButton(
-                          onPressed: () => Navigator.pop(context),
-                          child: const Text('閉じる'),
-                        ),
-                      ],
-                    );
-                  },
-                );
-              },
-              child: const Text('お寺の情報を表示する'),
-            ),
             GoogleMapView(_ref),
+            // TODO(s14t284): 開発用に残しているだけなので削除予定
+            if (kDebugMode)
+              Column(
+                children: [
+                  ElevatedButton(
+                    onPressed: () async {
+                      await _ref.read(signInPresenterProvider.notifier).logout();
+                      _ref.read(routerProvider).go(RouterPath.signIn);
+                    },
+                    child: const Text('サインイン画面に戻る'),
+                  ),
+                  ElevatedButton(
+                    onPressed: () async {
+                      final pilgrimage = _ref.watch(pilgrimageRepositoryProvider);
+                      final url = await pilgrimage.getTempleImageUrl(
+                        userState?.pilgrimage?.nowPilgrimageId.toString() ?? '1',
+                        '1.jpg',
+                      );
+                      final temple = _ref.watch(templeRepositoryProvider);
+                      final templeInfo = await temple.getTempleInfo(1);
+                      await showDialog<void>(
+                        context: context,
+                        builder: (BuildContext context) {
+                          return AlertDialog(
+                            title: Text(templeInfo.prefecture),
+                            content: Image.network(url),
+                            actions: <Widget>[
+                              ElevatedButton(
+                                onPressed: () => Navigator.pop(context),
+                                child: const Text('閉じる'),
+                              ),
+                            ],
+                          );
+                        },
+                      );
+                    },
+                    child: const Text('お寺の情報を表示する'),
+                  ),
+                ],
+              )
           ],
         ),
       ),

--- a/lib/ui/pages/profile/profile_page.dart
+++ b/lib/ui/pages/profile/profile_page.dart
@@ -180,10 +180,11 @@ class _ProfilePageBody extends StatelessWidget {
           },
           selectedTextStyle: const TextStyle(
             fontWeight: FontWeight.bold,
+            color: ColorStyle.white,
           ),
           unSelectedTextStyle: const TextStyle(
-            color: Colors.black54,
-            fontWeight: FontWeight.w200,
+            color: Colors.black87,
+            fontWeight: FontWeight.w400,
           ),
           selectedIndex: state.selectedTabIndex,
         ),

--- a/lib/ui/pages/profile/profile_page.dart
+++ b/lib/ui/pages/profile/profile_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_toggle_tab/flutter_toggle_tab.dart';
 import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
 import 'package:virtualpilgrimage/router.dart';
+import 'package:virtualpilgrimage/ui/components/bottom_navigation.dart';
 import 'package:virtualpilgrimage/ui/components/my_app_bar.dart';
 import 'package:virtualpilgrimage/ui/components/profile_icon.dart';
 import 'package:virtualpilgrimage/ui/pages/profile/components/profile_health_card.dart';
@@ -51,6 +52,7 @@ class ProfilePage extends ConsumerWidget {
           },
         ),
       ),
+      bottomNavigationBar: BottomNavigation(ref),
     );
   }
 }

--- a/lib/ui/style/theme.dart
+++ b/lib/ui/style/theme.dart
@@ -1,38 +1,15 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 import 'color.dart';
 
 extension AppTheme on ThemeData {
   static final theme = ThemeData(
+    useMaterial3: true,
+    colorSchemeSeed: ColorStyle.primary,
     unselectedWidgetColor: ColorStyle.grey,
     focusColor: ColorStyle.primary,
-    primaryColor: ColorStyle.primary,
     primaryColorDark: ColorStyle.primaryDark,
     primaryColorLight: ColorStyle.primaryLight,
     backgroundColor: ColorStyle.white,
-    appBarTheme: const AppBarTheme(
-      systemOverlayStyle: SystemUiOverlayStyle.dark,
-      centerTitle: true,
-      backgroundColor: ColorStyle.white,
-      elevation: 0,
-    ),
-    // ダークモードにしても通常色にしてもバッテリーなどの表示に支障を与えないようにしている
-    // ref. https://zenn.dev/sugitlab/articles/d49a056941d511
-    primarySwatch: MaterialColor(
-      ColorStyle.white.value,
-      <int, Color>{
-        50: Color(ColorStyle.white.value),
-        100: Color(ColorStyle.white.value),
-        200: Color(ColorStyle.white.value),
-        300: Color(ColorStyle.white.value),
-        400: Color(ColorStyle.white.value),
-        500: Color(ColorStyle.white.value),
-        600: Color(ColorStyle.white.value),
-        700: Color(ColorStyle.white.value),
-        800: Color(ColorStyle.white.value),
-        900: Color(ColorStyle.white.value),
-      },
-    ),
   );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -479,7 +479,7 @@ packages:
       name: go_router
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.7"
+    version: "4.5.1"
   google_maps_flutter:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   firebase_crashlytics: ^2.8.7
   # utilities
   flutter_riverpod: ^2.0.0-dev.9
-  go_router: ^4.2.7
+  go_router: ^4.5.1
   flutter_signin_button: ^2.0.0
   google_sign_in: ^5.4.1
   logger: ^1.1.0


### PR DESCRIPTION
@itomizu 
ログイン後の画面にボトムナビゲーションバーを実装しました。
map ページ, プロフィールページをそれぞれ遷移できるようにしています。

また、[Material3](https://m3.material.io/) をデザインに利用するようにしてみました。

<img width="200" alt="image" src="https://user-images.githubusercontent.com/20528138/195971755-06208b62-3929-4b0a-994c-b83f3b7b7903.png"><img width="198" alt="image" src="https://user-images.githubusercontent.com/20528138/195971761-c9d70f52-8dae-4f58-8641-ad6d1d13cbcb.png"><img width="198" alt="image" src="https://user-images.githubusercontent.com/20528138/195971768-a477f23f-97e8-419c-ae2a-c56b352c6432.png">

