### PR TITLE
ビジネスロジックの実装ミスの修正

### DIFF
--- a/lib/domain/pilgrimage/update_pilgrimage_progress_interactor.dart
+++ b/lib/domain/pilgrimage/update_pilgrimage_progress_interactor.dart
@@ -78,7 +78,12 @@ class UpdatePilgrimageProgressInteractor extends UpdatePilgrimageProgressUsecase
       );
 
       /// 2. 移動距離 > 次の札所までの距離 の間、で移動距離を減らしながら次に目指すべき札所を導出する
-      movingDistance = healthFromLastUpdatedAt.distance;
+      movingDistance = user.pilgrimage.movingDistance + healthFromLastUpdatedAt.distance;
+      _logger.d(
+        'calc pilgrimage progress '
+        '[movingDistance][$movingDistance]'
+        '[templeDistance][${nowTempleInfo.distance}]',
+      );
       while (movingDistance >= nowTempleInfo.distance) {
         reachedPilgrimageIdList.add(nowTempleInfo.id);
         // 札所までの距離を移動距離から引いて、札所を更新

--- a/lib/infrastructure/user/health_repository_impl.dart
+++ b/lib/infrastructure/user/health_repository_impl.dart
@@ -49,11 +49,15 @@ class HealthRepositoryImpl implements HealthRepository {
     // アプリを登録した時点をヘルスケア情報の集計起点とする
     DateTime fixDt(DateTime dt) => dt.compareTo(createdAt) == 1 ? dt : createdAt;
 
+    _logger.d('collect health info start [targetDateTime][$targetDateTime]');
     try {
       // 今日、昨日1日、過去一週間、過去一ヶ月間、過去全ての3パターンでヘルスケア情報を取得
       // 今日
-      final healthOfToday =
-          await _getHealthData(fixDt(targetDateTime), _lastTime(targetDateTime), types);
+      final healthOfToday = await _getHealthData(
+        DateTime(targetDateTime.year, targetDateTime.month, targetDateTime.day),
+        _lastTime(targetDateTime),
+        types,
+      );
 
       // 昨日
       final toDate = _lastTime(targetDateTime.subtract(const Duration(days: 1)));

--- a/test/domain/pilgrimage/update_pilgrimage_progress_interactor_test.dart
+++ b/test/domain/pilgrimage/update_pilgrimage_progress_interactor_test.dart
@@ -69,7 +69,7 @@ void main() {
             pilgrimage: user.pilgrimage.copyWith(
               nowPilgrimageId: 2, // 86 -> 87 -> 88(スタート地点がリセットされて1) -> 2
               lap: 2, // 88にたどり着いたのでlap++
-              movingDistance: 1600, // 27000 - (7000 + 17000 + 1400)
+              movingDistance: 1600 + 100, // (27000 - (7000 + 17000 + 1400)) + 100(元々ユーザ情報に保持していた距離)
               updatedAt: CustomizableDateTime.current,
             ),
           ),
@@ -111,7 +111,7 @@ VirtualPilgrimageUser defaultUser() {
     userStatus: UserStatus.created,
     createdAt: DateTime.utc(2022),
     updatedAt: DateTime.utc(2022),
-    pilgrimage: PilgrimageInfo(id: 'dummyId', nowPilgrimageId: 86, updatedAt: DateTime.utc(2022)),
+    pilgrimage: PilgrimageInfo(id: 'dummyId', nowPilgrimageId: 86, updatedAt: DateTime.utc(2022), movingDistance: 100),
   );
 }
 

--- a/test/infrastructure/user/health_repository_impl_test.dart
+++ b/test/infrastructure/user/health_repository_impl_test.dart
@@ -48,10 +48,11 @@ void main() {
       when(mockHealthFactory.requestAuthorization(any)).thenAnswer((_) => Future.value(true));
 
       /// 今日
+      /// 今日の集計だけ対象時間からではなく、当日の00:00:00-23:59:59まで集計
       when(
         mockHealthFactory.getHealthDataFromTypes(
-          targetDate,
-          targetToDate.add(const Duration(days: 1)),
+          DateTime(2022, 9, 19),
+          DateTime(2022, 9, 19, 23, 59, 59, 999, 999),
           types,
         ),
       ).thenAnswer(
@@ -191,8 +192,8 @@ void main() {
           /// 今日
           when(
             mockHealthFactory.getHealthDataFromTypes(
-              targetDate,
-              targetToDate.add(const Duration(days: 1)),
+              DateTime(2022, 9, 19),
+              DateTime(2022, 9, 19, 23, 59, 59, 999, 999),
               iosTypes,
             ),
           ).thenAnswer(
@@ -264,10 +265,27 @@ void main() {
       });
     });
 
-    group('getHealthInfo', () {
+    group('getHealthByPeriod', () {
       test('正常系', () async {
         // given
         const expected = HealthByPeriod(steps: 427, distance: 670, burnedCalorie: 468);
+
+        /// 今日
+        when(
+          mockHealthFactory.getHealthDataFromTypes(
+            targetDate,
+            DateTime(2022, 9, 19, 23, 59, 59, 999, 999),
+            types,
+          ),
+        ).thenAnswer(
+          (_) => Future.value([
+                // @formatter:off
+            HealthDataPoint(NumericHealthValue(468), HealthDataType.ACTIVE_ENERGY_BURNED, HealthDataUnit.KILOCALORIE, DateTime(2022, 9, 12), DateTime(2022, 9, 18), PlatformType.ANDROID, defaultDeviceId, defaultSourceId, defaultSourceName),
+            HealthDataPoint(NumericHealthValue(427), HealthDataType.STEPS, HealthDataUnit.COUNT, DateTime(2022, 9, 12), DateTime(2022, 9, 18), PlatformType.ANDROID, defaultDeviceId, defaultSourceId, defaultSourceName),
+            HealthDataPoint(NumericHealthValue(670), HealthDataType.DISTANCE_DELTA, HealthDataUnit.METER, DateTime(2022, 9, 12), DateTime(2022, 9, 18), PlatformType.ANDROID, defaultDeviceId, defaultSourceId, defaultSourceName),
+            // @formatter:on
+          ]),
+        );
 
         // when
         final actual = await target.getHealthByPeriod(


### PR DESCRIPTION
@itomizu 
動作を確認していてビジネスロジックについて以下の点に実装ミスがあることがわかったので修正しました。
いずれも致命的なミスでした。申し訳ありません。
お手数をおかけしますがご確認よろしくお願いいたします 🙇‍♂️ 

- お遍路の進捗を計算する時、現状のユーザの移動距離を使わず、ヘルスケア情報から取得した距離だけを使っており、最後にヘルスケア情報から取得した距離だけをDBに保存していました。。
- 当日分のヘルスケア情報の取得範囲が情報を取得したい時間（≒ ページを表示した時間）から当日の 23:59:59 になっていたため、歩数や移動距離が 0 になっていた