### PR TITLE
テストバージョンリリースのための修正

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -94,12 +94,10 @@ android {
         targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
-        // 環境ごとにアプリケーションの表示名を修正
+        // 環境ごとにパッケージ名を修正
         if (dartEnvironmentVariables.FLAVOR != '') {
             applicationIdSuffix ".${dartEnvironmentVariables.FLAVOR}"
         }
-        resValue "string", "app_name", "com.virtualpilgrimage" +
-                (dartEnvironmentVariables.FLAVOR == 'prod' ? '.prod' : ".${dartEnvironmentVariables.FLAVOR}")
         // firebase関連のライブラリを使うことによる64k問題の回避のための設定
         multiDexEnabled true
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -57,6 +57,13 @@ tasks.whenTaskAdded { task ->
     }
 }
 
+// key.propertiesを読み込む
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file('key.properties')
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
 android {
     // https://firebase.google.com/docs/android/setup?hl=ja#register-app => 31
     // 2022/10現在、最新のバージョン（Android13）
@@ -92,7 +99,7 @@ android {
             applicationIdSuffix ".${dartEnvironmentVariables.FLAVOR}"
         }
         resValue "string", "app_name", "com.virtualpilgrimage" +
-                (dartEnvironmentVariables.FLAVOR == 'prod' ? '' : ".${dartEnvironmentVariables.FLAVOR}")
+                (dartEnvironmentVariables.FLAVOR == 'prod' ? '.prod' : ".${dartEnvironmentVariables.FLAVOR}")
         // firebase関連のライブラリを使うことによる64k問題の回避のための設定
         multiDexEnabled true
 
@@ -102,11 +109,26 @@ android {
         ]
     }
 
+    // ref. https://docs.codemagic.io/flutter-code-signing/android-code-signing/
+    signingConfigs {
+        release {
+            if (System.getenv()["CI"]) {
+                storeFile file(System.getenv()["CM_KEYSTORE_PATH"])
+                storePassword System.getenv()["CM_KEYSTORE_PASSWORD"]
+                keyAlias System.getenv()["CM_KEY_ALIAS"]
+                keyPassword System.getenv()["CM_KEY_PASSWORD"]
+            } else {
+                keyAlias keystoreProperties['keyAlias']
+                keyPassword keystoreProperties['keyPassword']
+                storeFile keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
+                storePassword keystoreProperties['storePassword']
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig signingConfigs.debug
+            signingConfig signingConfigs.release
         }
     }
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -59,7 +59,8 @@ tasks.whenTaskAdded { task ->
 
 android {
     // https://firebase.google.com/docs/android/setup?hl=ja#register-app => 31
-    compileSdkVersion 31
+    // 2022/10現在、最新のバージョン（Android13）
+    compileSdkVersion 33
     ndkVersion flutter.ndkVersion
 
     compileOptions {
@@ -80,8 +81,10 @@ android {
         // ref. https://firebase.google.com/docs/android/setup?hl=ja#register-app => minSdkVersion: 19
         // ref. https://pub.dev/packages/google_maps_flutter => minSdkVersion: 20
         // ref. https://twitter.com/_mono/status/1509452309398695936
+        // GoogleFit が Android5以降（sdkVersion = 21）対応なので、21
         minSdkVersion 21
-        targetSdkVersion flutter.targetSdkVersion
+        // 2022/10現在、最新のバージョン（Android13）
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         // 環境ごとにアプリケーションの表示名を修正

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,16 +2,16 @@
     package="com.virtualpilgrimage">
 
     <application
-        android:label="@string/app_name"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name">
         <activity
             android:name=".MainActivity"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:exported="true"
+            android:hardwareAccelerated="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
-            android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">巡礼ウォーク</string>
+</resources>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:virtualpilgrimage/analytics.dart';
@@ -15,11 +16,15 @@ Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   const flavor = String.fromEnvironment('FLAVOR', defaultValue: 'dev');
   await Firebase.initializeApp(options: _getFirebaseOptions(flavor));
-  runApp(const ProviderScope(child: _App()));
+  // flutter側で検知されるエラーをCrashlyticsに送信
+  FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterFatalError;
+  runApp(const ProviderScope(child: _App(flavor: flavor,)));
 }
 
 class _App extends ConsumerWidget {
-  const _App();
+  const _App({required this.flavor});
+
+  final String flavor;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -55,6 +60,7 @@ class _App extends ConsumerWidget {
       title: '巡礼ウォーク',
       locale: const Locale('ja'),
       theme: AppTheme.theme,
+      debugShowCheckedModeBanner: flavor != 'prod',
     );
   }
 }

--- a/lib/ui/pages/sign_in/sign_in_presenter.dart
+++ b/lib/ui/pages/sign_in/sign_in_presenter.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
 
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:virtualpilgrimage/analytics.dart';
 import 'package:virtualpilgrimage/domain/auth/sign_in_usecase.dart';
 import 'package:virtualpilgrimage/domain/exception/sign_in_exception.dart';
 import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
+import 'package:virtualpilgrimage/infrastructure/firebase/firebase_crashlytics_provider.dart';
 import 'package:virtualpilgrimage/logger.dart';
 import 'package:virtualpilgrimage/model/form_model.codegen.dart';
 import 'package:virtualpilgrimage/ui/pages/sign_in/sign_in_state.codegen.dart';
@@ -27,6 +29,7 @@ class SignInPresenter extends StateNotifier<SignInState> {
     _userState = _ref.watch(userStateProvider.state);
     _loginState = _ref.watch(loginStateProvider.state);
     _analytics = _ref.read(analyticsProvider);
+    _crashlytics = _ref.read(firebaseCrashlyticsProvider);
   }
 
   final Ref _ref;
@@ -34,6 +37,7 @@ class SignInPresenter extends StateNotifier<SignInState> {
   late final StateController<VirtualPilgrimageUser?> _userState;
   late final StateController<UserStatus?> _loginState;
   late final Analytics _analytics;
+  late final FirebaseCrashlytics _crashlytics;
 
   void onChangeEmail(FormModel emailOrNickname) =>
       state = state.onChangeEmailOrNickname(emailOrNickname);
@@ -59,6 +63,7 @@ class SignInPresenter extends StateNotifier<SignInState> {
           parameters: {'error': e},
         ),
       );
+      unawaited(_crashlytics.recordError(e, null));
     }
   }
 
@@ -150,6 +155,8 @@ class SignInPresenter extends StateNotifier<SignInState> {
           parameters: {'error': e, 'validationStatus': e.status.name},
         ),
       );
+      unawaited(_crashlytics.recordError(e, null));
+
     } on Exception catch (e) {
       unawaited(
         _analytics.logEvent(
@@ -157,6 +164,7 @@ class SignInPresenter extends StateNotifier<SignInState> {
           parameters: {'error': e},
         ),
       );
+      unawaited(_crashlytics.recordError(e, null));
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.0+1
+version: 0.1.0+1
 
 environment:
   sdk: ">=2.17.6 <3.0.0"


### PR DESCRIPTION
テストバージョンを使ってもらえるように、以下の修正を施しました。

- sdk version を修正
- アプリ自体のバージョンを修正
  - Store にリリースできた時のメジャーバージョンを 1 系とする
- prod フレーバーの時、`debug` バッチを表示しないように
- サインインに失敗した時に crashlitics にログを残すように