### PR TITLE
Firestore へのスタンプ画像の挿入形式の修正

### DIFF
--- a/firebase/temples/db_access.py
+++ b/firebase/temples/db_access.py
@@ -77,7 +77,7 @@ def main():
             u'geoPoint':geoPoint[i],
             u'id':id_,
             u'images':image_path[i],
-            u'stamp_images':stamp_image_path[i],
+            u'stamp_image':stamp_image_path,
             u'name':name[i],
             u'prefecture':prefecture[i],
             u'encodedPoints':str(encoded_points[i]),
@@ -111,13 +111,10 @@ def make_image_path(ids):
     return image_list
 
 def make_stamp_image_path(ids):
-    stamp_image_list = []
+    if len(ids) > 0:
+        id_ = ids[0]
+        return "https://firebasestorage.googleapis.com/v0/b/virtual-pilgrimage-dev.appspot.com/o/temples%2F"+str(id_)+"%2Fstamp.jpg?alt=media&token=6fe4c2ed-b204-4837-9c56-3b72f24e1186"
 
-    # TODO: 1つのパス(1.jpg)に対してのみしか対応できていないので改良必要
-    for id_ in ids:
-        image_path = "https://firebasestorage.googleapis.com/v0/b/virtual-pilgrimage-dev.appspot.com/o/temples%2F"+str(id_)+"%2Fstamp.jpg?alt=media&token=6fe4c2ed-b204-4837-9c56-3b72f24e1186"
-        stamp_image_list.append([image_path])
-
-    return stamp_image_list
+    return ""
 
 main()


### PR DESCRIPTION
@itomizu @kmsz46 

スタンプ画像は1つしか存在しないものの、複数受け付けれる形式になっていたため、修正しました。
軽微な修正であるためセルフマージします。

ref. https://github.com/s14t284/virtual-pilgrimage/pull/56#discussion_r1008771147