### PR TITLE
プロフィールページ・ユーザ情報を編集した後の挙動を微修正

### DIFF
--- a/lib/ui/components/molecules/my_drawer.dart
+++ b/lib/ui/components/molecules/my_drawer.dart
@@ -6,7 +6,6 @@ import 'package:virtualpilgrimage/analytics.dart';
 import 'package:virtualpilgrimage/domain/auth/sign_in_usecase.dart';
 import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
 import 'package:virtualpilgrimage/router.dart';
-import 'package:virtualpilgrimage/ui/components/bottom_navigation.dart';
 import 'package:virtualpilgrimage/ui/style/font.dart';
 
 class MyDrawer extends ConsumerWidget {
@@ -25,14 +24,8 @@ class MyDrawer extends ConsumerWidget {
         children: [
           _headerWidget(context, userState),
           // いずれもクリックした際にページタブをリセットしておく
-          _menuWidget(context, Icons.edit_outlined, 'ユーザ情報編集', () {
-            ref.read(pageTypeProvider.notifier).state = PageType.home;
-            _moveEditPage(context, ref);
-          }),
-          _menuWidget(context, Icons.logout_outlined, 'ログアウト', () {
-            ref.read(pageTypeProvider.notifier).state = PageType.home;
-            _logout(context, ref);
-          }),
+          _menuWidget(context, Icons.edit_outlined, 'ユーザ情報編集', () => _moveEditPage(context, ref)),
+          _menuWidget(context, Icons.logout_outlined, 'ログアウト', () => _logout(context, ref)),
         ],
       );
     }

--- a/lib/ui/components/molecules/my_drawer.dart
+++ b/lib/ui/components/molecules/my_drawer.dart
@@ -6,6 +6,7 @@ import 'package:virtualpilgrimage/analytics.dart';
 import 'package:virtualpilgrimage/domain/auth/sign_in_usecase.dart';
 import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
 import 'package:virtualpilgrimage/router.dart';
+import 'package:virtualpilgrimage/ui/components/bottom_navigation.dart';
 import 'package:virtualpilgrimage/ui/style/font.dart';
 
 class MyDrawer extends ConsumerWidget {
@@ -23,8 +24,15 @@ class MyDrawer extends ConsumerWidget {
       drawerChild = ListView(
         children: [
           _headerWidget(context, userState),
-          _menuWidget(context, Icons.edit_outlined, 'ユーザ情報編集', () => _moveEditPage(context, ref)),
-          _menuWidget(context, Icons.logout_outlined, 'ログアウト', () => _logout(context, ref)),
+          // いずれもクリックした際にページタブをリセットしておく
+          _menuWidget(context, Icons.edit_outlined, 'ユーザ情報編集', () {
+            ref.read(pageTypeProvider.notifier).state = PageType.home;
+            _moveEditPage(context, ref);
+          }),
+          _menuWidget(context, Icons.logout_outlined, 'ログアウト', () {
+            ref.read(pageTypeProvider.notifier).state = PageType.home;
+            _logout(context, ref);
+          }),
         ],
       );
     }

--- a/lib/ui/pages/home/home_presenter.dart
+++ b/lib/ui/pages/home/home_presenter.dart
@@ -14,6 +14,7 @@ import 'package:virtualpilgrimage/domain/user/health/update_health_usecase.dart'
 import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
 import 'package:virtualpilgrimage/infrastructure/firebase/firebase_crashlytics_provider.dart';
 import 'package:virtualpilgrimage/logger.dart';
+import 'package:virtualpilgrimage/ui/components/bottom_navigation.dart';
 
 import 'home_state.codegen.dart';
 
@@ -28,6 +29,7 @@ class HomePresenter extends StateNotifier<HomeState> {
     _crashlytics = _ref.read(firebaseCrashlyticsProvider);
     _templeRepository = _ref.read(templeRepositoryProvider);
     _userStateNotifier = _ref.read(userStateProvider.notifier);
+    _ref.read(pageTypeProvider.notifier).state = PageType.home;
     initialize();
   }
 

--- a/lib/ui/pages/profile/profile_presenter.dart
+++ b/lib/ui/pages/profile/profile_presenter.dart
@@ -13,6 +13,7 @@ import 'package:virtualpilgrimage/domain/user/user_repository.dart';
 import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
 import 'package:virtualpilgrimage/infrastructure/firebase/firebase_crashlytics_provider.dart';
 import 'package:virtualpilgrimage/logger.dart';
+import 'package:virtualpilgrimage/ui/components/bottom_navigation.dart';
 import 'package:virtualpilgrimage/ui/pages/profile/profile_state.codegen.dart';
 
 final profileUserProvider =
@@ -48,6 +49,7 @@ final profileProvider =
 
 class ProfilePresenter extends StateNotifier<ProfileState> {
   ProfilePresenter(this._ref) : super(ProfileState(selectedTabIndex: 0)) {
+    _ref.read(pageTypeProvider.notifier).state = PageType.profile;
     _updateUserProfileImageInteractor = _ref.read(updateUserProfileImageUsecaseProvider);
     _userIconRepository = _ref.read(userIconRepositoryProvider);
     _analytics = _ref.read(analyticsProvider);


### PR DESCRIPTION
表題の通りです。以下を修正しました。
- プロフィールページの描画ではstate を更新せず、取得できたユーザ情報をそのまま使う
- 情報を編集した後の PageType タブの状態の正常化

軽微な修正なので、#55 がマージされたらマージします。