### PR TITLE
release-drafter の設定

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,61 @@
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+  - title: '📝 Document'
+    labels:
+      - 'doc'
+      - 'documentation'
+  - title: '🔧 Refactoring'
+    label: 'refactor'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+      - 'major-release'
+  minor:
+    labels:
+      - 'minor'
+      - 'release'
+      - 'minor-release'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+autolabeler:
+  - label: 'feature'
+    branch:
+      - '/^feature\/.+/'
+  - label: 'bug'
+    branch:
+      - '/^fix\/.+/'
+  - label: chore
+    branch:
+      - '/^chore\/.+/'
+  - label: refactor
+    branch:
+      - '/^(refactor|refactoring)\/.+/'
+  - label: doc
+    branch:
+      - '/^doc(umentation)?\/.+/'
+    files:
+      - '*.md'
+  - label: enhancement
+    branch:
+      - '/^(enhancement|improve|enhance)\/.+/'
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,15 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
release-drafter の設定をしました。自動でリリースノートを Draft で書いてくれる仕組みです。
参考：https://github.com/release-drafter/release-drafter

こちらを使って、Draft Release を作成し、Publish することで本番環境のビルドを走らせようと考えています。