### PR TITLE
ヘルスケア取得ロジックを修正・プロフィールページの表示崩れ対策のためにwidgetサイズを修正

### DIFF
--- a/lib/infrastructure/temple/temple_repository_impl.dart
+++ b/lib/infrastructure/temple/temple_repository_impl.dart
@@ -79,8 +79,6 @@ class TempleRepositoryImpl extends TempleRepository {
           templeInfoMap.addAll({data.id: data});
         }
       }
-      // ignore: avoid_print
-      print(templeInfoMap);
       _reader(templeInfoCache.state).state = templeInfoMap;
     } on FirebaseException catch (e) {
       throw DatabaseException(

--- a/lib/infrastructure/user/health_repository_impl.dart
+++ b/lib/infrastructure/user/health_repository_impl.dart
@@ -52,10 +52,10 @@ class HealthRepositoryImpl implements HealthRepository {
     _logger.d('collect health info start [targetDateTime][$targetDateTime]');
     try {
       // 今日、昨日1日、過去一週間、過去一ヶ月間、過去全ての3パターンでヘルスケア情報を取得
-      // 今日
+      // 今日のデータは今日の00:00:00 ~ 現在時刻までを取得
       final healthOfToday = await _getHealthData(
         DateTime(targetDateTime.year, targetDateTime.month, targetDateTime.day),
-        _lastTime(targetDateTime),
+        targetDateTime,
         types,
       );
 
@@ -86,6 +86,7 @@ class HealthRepositoryImpl implements HealthRepository {
       }
 
       final totalHealth = _aggregateHealthInfo(healthOfTotal);
+      print(_aggregateHealthInfo(healthOfToday));
       final health = HealthInfo(
         today: _aggregateHealthInfo(healthOfToday),
         yesterday: _aggregateHealthInfo(healthOfYesterday),
@@ -95,6 +96,7 @@ class HealthRepositoryImpl implements HealthRepository {
         totalSteps: totalHealth.steps,
         totalDistance: totalHealth.distance,
       );
+      _aggregateHealthInfo(healthOfToday);
       _logger.d(health);
       return health;
     } on HealthException catch (e) {
@@ -194,6 +196,8 @@ class HealthRepositoryImpl implements HealthRepository {
           break;
         // 消費カロリー[kcal]
         case HealthDataType.ACTIVE_ENERGY_BURNED:
+          print(p);
+          print(val);
           burnedCalorie += val;
           break;
         // ignore: no_default_cases

--- a/lib/infrastructure/user/health_repository_impl.dart
+++ b/lib/infrastructure/user/health_repository_impl.dart
@@ -86,7 +86,6 @@ class HealthRepositoryImpl implements HealthRepository {
       }
 
       final totalHealth = _aggregateHealthInfo(healthOfTotal);
-      print(_aggregateHealthInfo(healthOfToday));
       final health = HealthInfo(
         today: _aggregateHealthInfo(healthOfToday),
         yesterday: _aggregateHealthInfo(healthOfYesterday),
@@ -196,8 +195,6 @@ class HealthRepositoryImpl implements HealthRepository {
           break;
         // 消費カロリー[kcal]
         case HealthDataType.ACTIVE_ENERGY_BURNED:
-          print(p);
-          print(val);
           burnedCalorie += val;
           break;
         // ignore: no_default_cases

--- a/lib/ui/components/molecules/pilgrimage_progress_card.dart
+++ b/lib/ui/components/molecules/pilgrimage_progress_card.dart
@@ -160,7 +160,7 @@ class PilgrimageProgressCard extends StatelessWidget {
                 _meterToKilometerString(movingDistance),
                 style: TextStyle(
                   color: Theme.of(context).colorScheme.onSecondaryContainer,
-                  fontSize: FontSize.mediumSize + 4,
+                  fontSize: FontSize.mediumSize + 2,
                   fontWeight: FontWeight.w900,
                 ),
               ),
@@ -181,7 +181,7 @@ class PilgrimageProgressCard extends StatelessWidget {
                 _meterToKilometerString(nextDistance),
                 style: TextStyle(
                   color: Theme.of(context).colorScheme.onSecondaryContainer,
-                  fontSize: FontSize.mediumSize + 4,
+                  fontSize: FontSize.mediumSize + 2,
                   fontWeight: FontWeight.w900,
                 ),
               ),

--- a/lib/ui/components/molecules/pilgrimage_progress_card.dart
+++ b/lib/ui/components/molecules/pilgrimage_progress_card.dart
@@ -62,8 +62,8 @@ Widget pilgrimageProgressCardProvider(
         );
       }
       return SizedBox(
-        height: 170,
-        width: MediaQuery.of(context).size.width / 10 * 9,
+        height: 140,
+        width: MediaQuery.of(context).size.width / 10 * 9.5,
         child: childWidget,
       );
     },
@@ -87,7 +87,7 @@ class PilgrimageProgressCard extends StatelessWidget {
     return Card(
       elevation: 0.5,
       shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: BorderRadius.circular(12),
         side: const BorderSide(
           color: Colors.transparent,
           width: 0.5,
@@ -95,7 +95,7 @@ class PilgrimageProgressCard extends StatelessWidget {
       ),
       color: Theme.of(context).colorScheme.onSecondary,
       child: Padding(
-        padding: const EdgeInsets.all(8),
+        padding: const EdgeInsets.only(left: 8, right: 8),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceAround,
           children: [
@@ -143,11 +143,11 @@ class PilgrimageProgressCard extends StatelessWidget {
     final movingDistance =
         pilgrimageInfo.movingDistance < nextDistance ? pilgrimageInfo.movingDistance : nextDistance;
     return CircularPercentIndicator(
-      radius: 64,
-      lineWidth: 18,
+      radius: 60,
+      lineWidth: 16,
+      percent: _calcPercent(pilgrimageInfo.movingDistance, nextDistance),
       backgroundColor: Theme.of(context).colorScheme.inversePrimary,
       progressColor: Theme.of(context).colorScheme.primary,
-      percent: _calcPercent(pilgrimageInfo.movingDistance, nextDistance),
       animation: true,
       center: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -160,7 +160,7 @@ class PilgrimageProgressCard extends StatelessWidget {
                 _meterToKilometerString(movingDistance),
                 style: TextStyle(
                   color: Theme.of(context).colorScheme.onSecondaryContainer,
-                  fontSize: FontSize.largeSize - 4,
+                  fontSize: FontSize.mediumSize + 4,
                   fontWeight: FontWeight.w900,
                 ),
               ),
@@ -169,10 +169,10 @@ class PilgrimageProgressCard extends StatelessWidget {
           ),
           Divider(
             color: Theme.of(context).colorScheme.onSecondaryContainer,
-            height: 3,
-            indent: 30,
-            endIndent: 30,
-            thickness: 2,
+            height: 2,
+            indent: 25,
+            endIndent: 25,
+            thickness: 1.5,
           ),
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
@@ -181,7 +181,7 @@ class PilgrimageProgressCard extends StatelessWidget {
                 _meterToKilometerString(nextDistance),
                 style: TextStyle(
                   color: Theme.of(context).colorScheme.onSecondaryContainer,
-                  fontSize: FontSize.largeSize - 4,
+                  fontSize: FontSize.mediumSize + 4,
                   fontWeight: FontWeight.w900,
                 ),
               ),

--- a/lib/ui/components/molecules/profile_health_card.dart
+++ b/lib/ui/components/molecules/profile_health_card.dart
@@ -25,23 +25,25 @@ class ProfileHealthCard extends StatelessWidget {
       child: Stack(
         children: [
           Card(
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
             color: backgroundColor,
             child: Padding(
-              padding: const EdgeInsetsDirectional.all(12),
+              padding: const EdgeInsetsDirectional.only(top: 8, bottom: 8, start: 12, end: 12),
               child: Column(
                 children: [
-                  const SizedBox(height: 12),
-                  Text(
-                    title,
-                    style: TextStyle(
-                      color: textColor,
-                      fontSize: FontSize.mediumSize,
-                      fontWeight: FontWeight.w600,
-                    ),
-                    textAlign: TextAlign.center,
-                  ),
                   const SizedBox(height: 8),
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 8),
+                    child: Text(
+                      title,
+                      style: TextStyle(
+                        color: textColor,
+                        fontSize: FontSize.mediumSize,
+                        fontWeight: FontWeight.w600,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
                   Text(
                     value,
                     style: TextStyle(
@@ -54,7 +56,7 @@ class ProfileHealthCard extends StatelessWidget {
                     alignment: Alignment.centerRight,
                     child: Text(
                       unit,
-                      style: TextStyle(color: textColor, fontWeight: FontWeight.w900),
+                      style: TextStyle(fontSize: FontSize.mediumSize, color: textColor, fontWeight: FontWeight.w900),
                       textAlign: TextAlign.right,
                     ),
                   )
@@ -62,7 +64,7 @@ class ProfileHealthCard extends StatelessWidget {
               ),
             ),
           ),
-          Positioned(top: 8, right: 4, child: Icon(icon, color: textColor, size: 28))
+          Positioned(top: 12, right: 8, child: Icon(icon, color: textColor, size: 20))
         ],
       ),
     );

--- a/lib/ui/pages/home/home_page.dart
+++ b/lib/ui/pages/home/home_page.dart
@@ -38,9 +38,10 @@ class HomePageBody extends StatelessWidget {
     return ColoredBox(
       color: Theme.of(context).backgroundColor,
       child: SafeArea(
-        child: ListView(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: [
-            const GoogleMapView(height: 300),
+            GoogleMapView(height: MediaQuery.of(context).size.height / 5 * 2),
             pilgrimageProgressCardProvider(context, userState!, _ref),
             _healthCards(context, userState, notifier),
           ],

--- a/lib/ui/pages/profile/profile_page.dart
+++ b/lib/ui/pages/profile/profile_page.dart
@@ -114,7 +114,7 @@ class _ProfilePageBody extends ConsumerWidget {
             icon: Icons.map_outlined,
           ),
           ProfileHealthCard(
-            title: '消費カロリー',
+            title: 'カロリー',
             value: h.burnedCalorie.toString(),
             unit: 'kcal',
             backgroundColor: Colors.orangeAccent,
@@ -124,7 +124,7 @@ class _ProfilePageBody extends ConsumerWidget {
       }
     }
     return SizedBox(
-      height: 200,
+      height: 180,
       child: Column(
         children: [
           FlutterToggleTab(
@@ -143,7 +143,7 @@ class _ProfilePageBody extends ConsumerWidget {
             ),
             selectedIndex: state.selectedTabIndex,
           ),
-          const SizedBox(height: 12),
+          const SizedBox(height: 8),
           // クラッシュ対策のため、全てのヘルスチェック情報を取得できているときに表示
           if (healthCards.length == notifier.tabLabels().length)
             Row(children: healthCards[state.selectedTabIndex]),

--- a/test/infrastructure/user/health_repository_impl_test.dart
+++ b/test/infrastructure/user/health_repository_impl_test.dart
@@ -31,7 +31,7 @@ void main() {
   });
 
   group('HealthRepositoryImpl', () {
-    final targetDate = DateTime(2022, 9, 19, 11, 0);
+    final targetDateTime = DateTime(2022, 9, 19, 11, 0);
     final targetToDate = DateTime(2022, 9, 18, 23, 59, 59, 999, 999);
     final yesterday = DateTime(2022, 9, 18);
     final lastWeek = DateTime(2022, 9, 12);
@@ -48,11 +48,11 @@ void main() {
       when(mockHealthFactory.requestAuthorization(any)).thenAnswer((_) => Future.value(true));
 
       /// 今日
-      /// 今日の集計だけ対象時間からではなく、当日の00:00:00-23:59:59まで集計
+      /// 今日の集計だけ対象時間からではなく、当日の00:00:00-現在時刻まで集計
       when(
         mockHealthFactory.getHealthDataFromTypes(
           DateTime(2022, 9, 19),
-          DateTime(2022, 9, 19, 23, 59, 59, 999, 999),
+          targetDateTime,
           types,
         ),
       ).thenAnswer(
@@ -130,7 +130,7 @@ void main() {
 
           // when
           final actual =
-              await target.getHealthInfo(targetDateTime: targetDate, createdAt: createdAt);
+              await target.getHealthInfo(targetDateTime: targetDateTime, createdAt: createdAt);
 
           // then
           expect(actual, expected);
@@ -144,7 +144,7 @@ void main() {
 
         test('ヘルスケア情報を取得できる(ユーザ登録から24時間経過していない)', () async {
           // given
-          final createdAt = targetDate.subtract(const Duration(hours: 12));
+          final createdAt = targetDateTime.subtract(const Duration(hours: 12));
           final expected = HealthInfo(
             today: const HealthByPeriod(steps: 427, distance: 670, burnedCalorie: 468),
             yesterday: const HealthByPeriod(steps: 5427, distance: 4679, burnedCalorie: 1468),
@@ -157,7 +157,7 @@ void main() {
 
           // when
           final actual =
-              await target.getHealthInfo(targetDateTime: targetDate, createdAt: createdAt);
+              await target.getHealthInfo(targetDateTime: targetDateTime, createdAt: createdAt);
 
           // then
           expect(actual, expected);
@@ -193,7 +193,7 @@ void main() {
           when(
             mockHealthFactory.getHealthDataFromTypes(
               DateTime(2022, 9, 19),
-              DateTime(2022, 9, 19, 23, 59, 59, 999, 999),
+              targetDateTime,
               iosTypes,
             ),
           ).thenAnswer(
@@ -251,7 +251,7 @@ void main() {
 
           // when
           final actual =
-              await target.getHealthInfo(targetDateTime: targetDate, createdAt: createdAt);
+              await target.getHealthInfo(targetDateTime: targetDateTime, createdAt: createdAt);
 
           // then
           expect(actual, expected);
@@ -273,7 +273,7 @@ void main() {
         /// 今日
         when(
           mockHealthFactory.getHealthDataFromTypes(
-            targetDate,
+            targetDateTime,
             DateTime(2022, 9, 19, 23, 59, 59, 999, 999),
             types,
           ),
@@ -289,7 +289,7 @@ void main() {
 
         // when
         final actual = await target.getHealthByPeriod(
-          from: targetDate,
+          from: targetDateTime,
           to: targetToDate.add(const Duration(days: 1)),
         );
 
@@ -298,7 +298,7 @@ void main() {
         verify(mockHealthFactory.requestAuthorization(any)).called(1);
         verify(
           mockHealthFactory.getHealthDataFromTypes(
-            targetDate,
+            targetDateTime,
             targetToDate.add(const Duration(days: 1)),
             types,
           ),


### PR DESCRIPTION
@itomizu 

当日のヘルスケア情報取得を 23:59:59 までではなく、00:00:00 ~ 取得時間の間としました。
Android のカロリー取得では、基礎代謝(?) を時間で割った値もカロリーに含まれていそうで、0時や深夜時点でも 1400kcal くらい加算されていました。
こちらの原因が当日のヘルスケア情報取得を 23:59:59 までとしていたためであったので、修正しました。
この変更によって、歩数・移動距離の取得に影響はありません。

また、依頼主の画面で表示崩れが起こっていたので、少しwidgetのサイズを修正しました。

軽微な修正であるため、セルフマージします