### PR TITLE
Flutter および依存先ライブラリのバージョンアップ

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.0.5",
+  "flutterSdkVersion": "3.3.7",
   "flavors": {}
 }

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -14,7 +14,7 @@ runs:
     - name: Setup Flutter
       uses: subosito/flutter-action@v2
       with:
-        flutter-version: '3.0.5'
+        flutter-version: '3.3.7'
         channel: 'stable'
         cache: true
 

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -15,8 +15,8 @@ $ brew install node
 $ npm install -g firebase-tools  # https://formulae.brew.sh/formula/firebase-cli
 # 以下は flutterfire を利用する場合のみ導入
 $ brew install fvm
-$ fvm install 3.0.5
-$ fvm use 3.0.5
+$ fvm install 3.3.7
+$ fvm use 3.3.7
 $ dart pub global activate flutterfire_cli
 # .zshrc など利用しているシェルの設定に以下を追加
 # export PATH="$PATH":"$HOME/.pub-cache/bin"

--- a/lib/domain/pilgrimage/update_pilgrimage_progress_result.codegen.freezed.dart
+++ b/lib/domain/pilgrimage/update_pilgrimage_progress_result.codegen.freezed.dart
@@ -39,7 +39,9 @@ abstract class $UpdatePilgrimageProgressResultCopyWith<$Res> {
   factory $UpdatePilgrimageProgressResultCopyWith(
           UpdatePilgrimageProgressResult value,
           $Res Function(UpdatePilgrimageProgressResult) then) =
-      _$UpdatePilgrimageProgressResultCopyWithImpl<$Res>;
+      _$UpdatePilgrimageProgressResultCopyWithImpl<$Res,
+          UpdatePilgrimageProgressResult>;
+  @useResult
   $Res call(
       {UpdatePilgrimageProgressResultStatus status,
       List<int> reachedPilgrimageIdList,
@@ -52,59 +54,63 @@ abstract class $UpdatePilgrimageProgressResultCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$UpdatePilgrimageProgressResultCopyWithImpl<$Res>
+class _$UpdatePilgrimageProgressResultCopyWithImpl<$Res,
+        $Val extends UpdatePilgrimageProgressResult>
     implements $UpdatePilgrimageProgressResultCopyWith<$Res> {
   _$UpdatePilgrimageProgressResultCopyWithImpl(this._value, this._then);
 
-  final UpdatePilgrimageProgressResult _value;
   // ignore: unused_field
-  final $Res Function(UpdatePilgrimageProgressResult) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? status = freezed,
-    Object? reachedPilgrimageIdList = freezed,
-    Object? virtualPolylineLatLngs = freezed,
+    Object? status = null,
+    Object? reachedPilgrimageIdList = null,
+    Object? virtualPolylineLatLngs = null,
     Object? virtualPosition = freezed,
     Object? updatedUser = freezed,
     Object? error = freezed,
   }) {
     return _then(_value.copyWith(
-      status: status == freezed
+      status: null == status
           ? _value.status
           : status // ignore: cast_nullable_to_non_nullable
               as UpdatePilgrimageProgressResultStatus,
-      reachedPilgrimageIdList: reachedPilgrimageIdList == freezed
+      reachedPilgrimageIdList: null == reachedPilgrimageIdList
           ? _value.reachedPilgrimageIdList
           : reachedPilgrimageIdList // ignore: cast_nullable_to_non_nullable
               as List<int>,
-      virtualPolylineLatLngs: virtualPolylineLatLngs == freezed
+      virtualPolylineLatLngs: null == virtualPolylineLatLngs
           ? _value.virtualPolylineLatLngs
           : virtualPolylineLatLngs // ignore: cast_nullable_to_non_nullable
               as List<LatLng>,
-      virtualPosition: virtualPosition == freezed
+      virtualPosition: freezed == virtualPosition
           ? _value.virtualPosition
           : virtualPosition // ignore: cast_nullable_to_non_nullable
               as LatLng?,
-      updatedUser: updatedUser == freezed
+      updatedUser: freezed == updatedUser
           ? _value.updatedUser
           : updatedUser // ignore: cast_nullable_to_non_nullable
               as VirtualPilgrimageUser?,
-      error: error == freezed
+      error: freezed == error
           ? _value.error
           : error // ignore: cast_nullable_to_non_nullable
               as Exception?,
-    ));
+    ) as $Val);
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $VirtualPilgrimageUserCopyWith<$Res>? get updatedUser {
     if (_value.updatedUser == null) {
       return null;
     }
 
     return $VirtualPilgrimageUserCopyWith<$Res>(_value.updatedUser!, (value) {
-      return _then(_value.copyWith(updatedUser: value));
+      return _then(_value.copyWith(updatedUser: value) as $Val);
     });
   }
 }
@@ -117,6 +123,7 @@ abstract class _$$_UpdatePilgrimageProgressResultCopyWith<$Res>
           $Res Function(_$_UpdatePilgrimageProgressResult) then) =
       __$$_UpdatePilgrimageProgressResultCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {UpdatePilgrimageProgressResultStatus status,
       List<int> reachedPilgrimageIdList,
@@ -131,48 +138,46 @@ abstract class _$$_UpdatePilgrimageProgressResultCopyWith<$Res>
 
 /// @nodoc
 class __$$_UpdatePilgrimageProgressResultCopyWithImpl<$Res>
-    extends _$UpdatePilgrimageProgressResultCopyWithImpl<$Res>
+    extends _$UpdatePilgrimageProgressResultCopyWithImpl<$Res,
+        _$_UpdatePilgrimageProgressResult>
     implements _$$_UpdatePilgrimageProgressResultCopyWith<$Res> {
   __$$_UpdatePilgrimageProgressResultCopyWithImpl(
       _$_UpdatePilgrimageProgressResult _value,
       $Res Function(_$_UpdatePilgrimageProgressResult) _then)
-      : super(_value, (v) => _then(v as _$_UpdatePilgrimageProgressResult));
+      : super(_value, _then);
 
-  @override
-  _$_UpdatePilgrimageProgressResult get _value =>
-      super._value as _$_UpdatePilgrimageProgressResult;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? status = freezed,
-    Object? reachedPilgrimageIdList = freezed,
-    Object? virtualPolylineLatLngs = freezed,
+    Object? status = null,
+    Object? reachedPilgrimageIdList = null,
+    Object? virtualPolylineLatLngs = null,
     Object? virtualPosition = freezed,
     Object? updatedUser = freezed,
     Object? error = freezed,
   }) {
     return _then(_$_UpdatePilgrimageProgressResult(
-      status: status == freezed
+      status: null == status
           ? _value.status
           : status // ignore: cast_nullable_to_non_nullable
               as UpdatePilgrimageProgressResultStatus,
-      reachedPilgrimageIdList: reachedPilgrimageIdList == freezed
+      reachedPilgrimageIdList: null == reachedPilgrimageIdList
           ? _value._reachedPilgrimageIdList
           : reachedPilgrimageIdList // ignore: cast_nullable_to_non_nullable
               as List<int>,
-      virtualPolylineLatLngs: virtualPolylineLatLngs == freezed
+      virtualPolylineLatLngs: null == virtualPolylineLatLngs
           ? _value._virtualPolylineLatLngs
           : virtualPolylineLatLngs // ignore: cast_nullable_to_non_nullable
               as List<LatLng>,
-      virtualPosition: virtualPosition == freezed
+      virtualPosition: freezed == virtualPosition
           ? _value.virtualPosition
           : virtualPosition // ignore: cast_nullable_to_non_nullable
               as LatLng?,
-      updatedUser: updatedUser == freezed
+      updatedUser: freezed == updatedUser
           ? _value.updatedUser
           : updatedUser // ignore: cast_nullable_to_non_nullable
               as VirtualPilgrimageUser?,
-      error: error == freezed
+      error: freezed == error
           ? _value.error
           : error // ignore: cast_nullable_to_non_nullable
               as Exception?,
@@ -237,30 +242,31 @@ class _$_UpdatePilgrimageProgressResult
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_UpdatePilgrimageProgressResult &&
-            const DeepCollectionEquality().equals(other.status, status) &&
+            (identical(other.status, status) || other.status == status) &&
             const DeepCollectionEquality().equals(
                 other._reachedPilgrimageIdList, _reachedPilgrimageIdList) &&
             const DeepCollectionEquality().equals(
                 other._virtualPolylineLatLngs, _virtualPolylineLatLngs) &&
-            const DeepCollectionEquality()
-                .equals(other.virtualPosition, virtualPosition) &&
-            const DeepCollectionEquality()
-                .equals(other.updatedUser, updatedUser) &&
-            const DeepCollectionEquality().equals(other.error, error));
+            (identical(other.virtualPosition, virtualPosition) ||
+                other.virtualPosition == virtualPosition) &&
+            (identical(other.updatedUser, updatedUser) ||
+                other.updatedUser == updatedUser) &&
+            (identical(other.error, error) || other.error == error));
   }
 
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      const DeepCollectionEquality().hash(status),
+      status,
       const DeepCollectionEquality().hash(_reachedPilgrimageIdList),
       const DeepCollectionEquality().hash(_virtualPolylineLatLngs),
-      const DeepCollectionEquality().hash(virtualPosition),
-      const DeepCollectionEquality().hash(updatedUser),
-      const DeepCollectionEquality().hash(error));
+      virtualPosition,
+      updatedUser,
+      error);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_UpdatePilgrimageProgressResultCopyWith<_$_UpdatePilgrimageProgressResult>
       get copyWith => __$$_UpdatePilgrimageProgressResultCopyWithImpl<
           _$_UpdatePilgrimageProgressResult>(this, _$identity);

--- a/lib/domain/temple/temple_image.codegen.freezed.dart
+++ b/lib/domain/temple/temple_image.codegen.freezed.dart
@@ -32,28 +32,32 @@ mixin _$TempleImage {
 abstract class $TempleImageCopyWith<$Res> {
   factory $TempleImageCopyWith(
           TempleImage value, $Res Function(TempleImage) then) =
-      _$TempleImageCopyWithImpl<$Res>;
+      _$TempleImageCopyWithImpl<$Res, TempleImage>;
+  @useResult
   $Res call({String path});
 }
 
 /// @nodoc
-class _$TempleImageCopyWithImpl<$Res> implements $TempleImageCopyWith<$Res> {
+class _$TempleImageCopyWithImpl<$Res, $Val extends TempleImage>
+    implements $TempleImageCopyWith<$Res> {
   _$TempleImageCopyWithImpl(this._value, this._then);
 
-  final TempleImage _value;
   // ignore: unused_field
-  final $Res Function(TempleImage) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? path = freezed,
+    Object? path = null,
   }) {
     return _then(_value.copyWith(
-      path: path == freezed
+      path: null == path
           ? _value.path
           : path // ignore: cast_nullable_to_non_nullable
               as String,
-    ));
+    ) as $Val);
   }
 }
 
@@ -64,25 +68,25 @@ abstract class _$$_TempleImageCopyWith<$Res>
           _$_TempleImage value, $Res Function(_$_TempleImage) then) =
       __$$_TempleImageCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call({String path});
 }
 
 /// @nodoc
-class __$$_TempleImageCopyWithImpl<$Res> extends _$TempleImageCopyWithImpl<$Res>
+class __$$_TempleImageCopyWithImpl<$Res>
+    extends _$TempleImageCopyWithImpl<$Res, _$_TempleImage>
     implements _$$_TempleImageCopyWith<$Res> {
   __$$_TempleImageCopyWithImpl(
       _$_TempleImage _value, $Res Function(_$_TempleImage) _then)
-      : super(_value, (v) => _then(v as _$_TempleImage));
+      : super(_value, _then);
 
-  @override
-  _$_TempleImage get _value => super._value as _$_TempleImage;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? path = freezed,
+    Object? path = null,
   }) {
     return _then(_$_TempleImage(
-      path: path == freezed
+      path: null == path
           ? _value.path
           : path // ignore: cast_nullable_to_non_nullable
               as String,
@@ -111,16 +115,16 @@ class _$_TempleImage extends _TempleImage {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_TempleImage &&
-            const DeepCollectionEquality().equals(other.path, path));
+            (identical(other.path, path) || other.path == path));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(path));
+  int get hashCode => Object.hash(runtimeType, path);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_TempleImageCopyWith<_$_TempleImage> get copyWith =>
       __$$_TempleImageCopyWithImpl<_$_TempleImage>(this, _$identity);
 

--- a/lib/domain/temple/temple_info.codegen.freezed.dart
+++ b/lib/domain/temple/temple_info.codegen.freezed.dart
@@ -43,7 +43,8 @@ mixin _$TempleInfo {
 abstract class $TempleInfoCopyWith<$Res> {
   factory $TempleInfoCopyWith(
           TempleInfo value, $Res Function(TempleInfo) then) =
-      _$TempleInfoCopyWithImpl<$Res>;
+      _$TempleInfoCopyWithImpl<$Res, TempleInfo>;
+  @useResult
   $Res call(
       {int id,
       String name,
@@ -59,68 +60,71 @@ abstract class $TempleInfoCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$TempleInfoCopyWithImpl<$Res> implements $TempleInfoCopyWith<$Res> {
+class _$TempleInfoCopyWithImpl<$Res, $Val extends TempleInfo>
+    implements $TempleInfoCopyWith<$Res> {
   _$TempleInfoCopyWithImpl(this._value, this._then);
 
-  final TempleInfo _value;
   // ignore: unused_field
-  final $Res Function(TempleInfo) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = freezed,
-    Object? name = freezed,
-    Object? prefecture = freezed,
-    Object? address = freezed,
-    Object? distance = freezed,
-    Object? encodedPoints = freezed,
-    Object? knowledge = freezed,
-    Object? stampImage = freezed,
-    Object? geoPoint = freezed,
-    Object? images = freezed,
+    Object? id = null,
+    Object? name = null,
+    Object? prefecture = null,
+    Object? address = null,
+    Object? distance = null,
+    Object? encodedPoints = null,
+    Object? knowledge = null,
+    Object? stampImage = null,
+    Object? geoPoint = null,
+    Object? images = null,
   }) {
     return _then(_value.copyWith(
-      id: id == freezed
+      id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
               as int,
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      prefecture: prefecture == freezed
+      prefecture: null == prefecture
           ? _value.prefecture
           : prefecture // ignore: cast_nullable_to_non_nullable
               as String,
-      address: address == freezed
+      address: null == address
           ? _value.address
           : address // ignore: cast_nullable_to_non_nullable
               as String,
-      distance: distance == freezed
+      distance: null == distance
           ? _value.distance
           : distance // ignore: cast_nullable_to_non_nullable
               as int,
-      encodedPoints: encodedPoints == freezed
+      encodedPoints: null == encodedPoints
           ? _value.encodedPoints
           : encodedPoints // ignore: cast_nullable_to_non_nullable
               as String,
-      knowledge: knowledge == freezed
+      knowledge: null == knowledge
           ? _value.knowledge
           : knowledge // ignore: cast_nullable_to_non_nullable
               as String,
-      stampImage: stampImage == freezed
+      stampImage: null == stampImage
           ? _value.stampImage
           : stampImage // ignore: cast_nullable_to_non_nullable
               as String,
-      geoPoint: geoPoint == freezed
+      geoPoint: null == geoPoint
           ? _value.geoPoint
           : geoPoint // ignore: cast_nullable_to_non_nullable
               as GeoPoint,
-      images: images == freezed
+      images: null == images
           ? _value.images
           : images // ignore: cast_nullable_to_non_nullable
               as List<String>,
-    ));
+    ) as $Val);
   }
 }
 
@@ -131,6 +135,7 @@ abstract class _$$_TempleInfoCopyWith<$Res>
           _$_TempleInfo value, $Res Function(_$_TempleInfo) then) =
       __$$_TempleInfoCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {int id,
       String name,
@@ -146,66 +151,65 @@ abstract class _$$_TempleInfoCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_TempleInfoCopyWithImpl<$Res> extends _$TempleInfoCopyWithImpl<$Res>
+class __$$_TempleInfoCopyWithImpl<$Res>
+    extends _$TempleInfoCopyWithImpl<$Res, _$_TempleInfo>
     implements _$$_TempleInfoCopyWith<$Res> {
   __$$_TempleInfoCopyWithImpl(
       _$_TempleInfo _value, $Res Function(_$_TempleInfo) _then)
-      : super(_value, (v) => _then(v as _$_TempleInfo));
+      : super(_value, _then);
 
-  @override
-  _$_TempleInfo get _value => super._value as _$_TempleInfo;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = freezed,
-    Object? name = freezed,
-    Object? prefecture = freezed,
-    Object? address = freezed,
-    Object? distance = freezed,
-    Object? encodedPoints = freezed,
-    Object? knowledge = freezed,
-    Object? stampImage = freezed,
-    Object? geoPoint = freezed,
-    Object? images = freezed,
+    Object? id = null,
+    Object? name = null,
+    Object? prefecture = null,
+    Object? address = null,
+    Object? distance = null,
+    Object? encodedPoints = null,
+    Object? knowledge = null,
+    Object? stampImage = null,
+    Object? geoPoint = null,
+    Object? images = null,
   }) {
     return _then(_$_TempleInfo(
-      id: id == freezed
+      id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
               as int,
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      prefecture: prefecture == freezed
+      prefecture: null == prefecture
           ? _value.prefecture
           : prefecture // ignore: cast_nullable_to_non_nullable
               as String,
-      address: address == freezed
+      address: null == address
           ? _value.address
           : address // ignore: cast_nullable_to_non_nullable
               as String,
-      distance: distance == freezed
+      distance: null == distance
           ? _value.distance
           : distance // ignore: cast_nullable_to_non_nullable
               as int,
-      encodedPoints: encodedPoints == freezed
+      encodedPoints: null == encodedPoints
           ? _value.encodedPoints
           : encodedPoints // ignore: cast_nullable_to_non_nullable
               as String,
-      knowledge: knowledge == freezed
+      knowledge: null == knowledge
           ? _value.knowledge
           : knowledge // ignore: cast_nullable_to_non_nullable
               as String,
-      stampImage: stampImage == freezed
+      stampImage: null == stampImage
           ? _value.stampImage
           : stampImage // ignore: cast_nullable_to_non_nullable
               as String,
-      geoPoint: geoPoint == freezed
+      geoPoint: null == geoPoint
           ? _value.geoPoint
           : geoPoint // ignore: cast_nullable_to_non_nullable
               as GeoPoint,
-      images: images == freezed
+      images: null == images
           ? _value._images
           : images // ignore: cast_nullable_to_non_nullable
               as List<String>,
@@ -283,18 +287,21 @@ class _$_TempleInfo extends _TempleInfo {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_TempleInfo &&
-            const DeepCollectionEquality().equals(other.id, id) &&
-            const DeepCollectionEquality().equals(other.name, name) &&
-            const DeepCollectionEquality()
-                .equals(other.prefecture, prefecture) &&
-            const DeepCollectionEquality().equals(other.address, address) &&
-            const DeepCollectionEquality().equals(other.distance, distance) &&
-            const DeepCollectionEquality()
-                .equals(other.encodedPoints, encodedPoints) &&
-            const DeepCollectionEquality().equals(other.knowledge, knowledge) &&
-            const DeepCollectionEquality()
-                .equals(other.stampImage, stampImage) &&
-            const DeepCollectionEquality().equals(other.geoPoint, geoPoint) &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.prefecture, prefecture) ||
+                other.prefecture == prefecture) &&
+            (identical(other.address, address) || other.address == address) &&
+            (identical(other.distance, distance) ||
+                other.distance == distance) &&
+            (identical(other.encodedPoints, encodedPoints) ||
+                other.encodedPoints == encodedPoints) &&
+            (identical(other.knowledge, knowledge) ||
+                other.knowledge == knowledge) &&
+            (identical(other.stampImage, stampImage) ||
+                other.stampImage == stampImage) &&
+            (identical(other.geoPoint, geoPoint) ||
+                other.geoPoint == geoPoint) &&
             const DeepCollectionEquality().equals(other._images, _images));
   }
 
@@ -302,19 +309,20 @@ class _$_TempleInfo extends _TempleInfo {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      const DeepCollectionEquality().hash(id),
-      const DeepCollectionEquality().hash(name),
-      const DeepCollectionEquality().hash(prefecture),
-      const DeepCollectionEquality().hash(address),
-      const DeepCollectionEquality().hash(distance),
-      const DeepCollectionEquality().hash(encodedPoints),
-      const DeepCollectionEquality().hash(knowledge),
-      const DeepCollectionEquality().hash(stampImage),
-      const DeepCollectionEquality().hash(geoPoint),
+      id,
+      name,
+      prefecture,
+      address,
+      distance,
+      encodedPoints,
+      knowledge,
+      stampImage,
+      geoPoint,
       const DeepCollectionEquality().hash(_images));
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_TempleInfoCopyWith<_$_TempleInfo> get copyWith =>
       __$$_TempleInfoCopyWithImpl<_$_TempleInfo>(this, _$identity);
 

--- a/lib/domain/temple/temple_repository.dart
+++ b/lib/domain/temple/temple_repository.dart
@@ -7,11 +7,12 @@ import 'temple_info.codegen.dart';
 final templeRepositoryProvider = Provider<TempleRepository>(
   (ref) => TempleRepositoryImpl(
     ref.read(firestoreProvider),
-    ref.read,
+    ref,
   ),
 );
 
 abstract class TempleRepository {
   Future<TempleInfo> getTempleInfo(int templeId);
+
   Future<void> getTempleInfoAll();
 }

--- a/lib/domain/user/health/health_by_period.codegen.freezed.dart
+++ b/lib/domain/user/health/health_by_period.codegen.freezed.dart
@@ -35,39 +35,42 @@ mixin _$HealthByPeriod {
 abstract class $HealthByPeriodCopyWith<$Res> {
   factory $HealthByPeriodCopyWith(
           HealthByPeriod value, $Res Function(HealthByPeriod) then) =
-      _$HealthByPeriodCopyWithImpl<$Res>;
+      _$HealthByPeriodCopyWithImpl<$Res, HealthByPeriod>;
+  @useResult
   $Res call({int steps, int distance, int burnedCalorie});
 }
 
 /// @nodoc
-class _$HealthByPeriodCopyWithImpl<$Res>
+class _$HealthByPeriodCopyWithImpl<$Res, $Val extends HealthByPeriod>
     implements $HealthByPeriodCopyWith<$Res> {
   _$HealthByPeriodCopyWithImpl(this._value, this._then);
 
-  final HealthByPeriod _value;
   // ignore: unused_field
-  final $Res Function(HealthByPeriod) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? steps = freezed,
-    Object? distance = freezed,
-    Object? burnedCalorie = freezed,
+    Object? steps = null,
+    Object? distance = null,
+    Object? burnedCalorie = null,
   }) {
     return _then(_value.copyWith(
-      steps: steps == freezed
+      steps: null == steps
           ? _value.steps
           : steps // ignore: cast_nullable_to_non_nullable
               as int,
-      distance: distance == freezed
+      distance: null == distance
           ? _value.distance
           : distance // ignore: cast_nullable_to_non_nullable
               as int,
-      burnedCalorie: burnedCalorie == freezed
+      burnedCalorie: null == burnedCalorie
           ? _value.burnedCalorie
           : burnedCalorie // ignore: cast_nullable_to_non_nullable
               as int,
-    ));
+    ) as $Val);
   }
 }
 
@@ -78,36 +81,35 @@ abstract class _$$_HealthByPeriodCopyWith<$Res>
           _$_HealthByPeriod value, $Res Function(_$_HealthByPeriod) then) =
       __$$_HealthByPeriodCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call({int steps, int distance, int burnedCalorie});
 }
 
 /// @nodoc
 class __$$_HealthByPeriodCopyWithImpl<$Res>
-    extends _$HealthByPeriodCopyWithImpl<$Res>
+    extends _$HealthByPeriodCopyWithImpl<$Res, _$_HealthByPeriod>
     implements _$$_HealthByPeriodCopyWith<$Res> {
   __$$_HealthByPeriodCopyWithImpl(
       _$_HealthByPeriod _value, $Res Function(_$_HealthByPeriod) _then)
-      : super(_value, (v) => _then(v as _$_HealthByPeriod));
+      : super(_value, _then);
 
-  @override
-  _$_HealthByPeriod get _value => super._value as _$_HealthByPeriod;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? steps = freezed,
-    Object? distance = freezed,
-    Object? burnedCalorie = freezed,
+    Object? steps = null,
+    Object? distance = null,
+    Object? burnedCalorie = null,
   }) {
     return _then(_$_HealthByPeriod(
-      steps: steps == freezed
+      steps: null == steps
           ? _value.steps
           : steps // ignore: cast_nullable_to_non_nullable
               as int,
-      distance: distance == freezed
+      distance: null == distance
           ? _value.distance
           : distance // ignore: cast_nullable_to_non_nullable
               as int,
-      burnedCalorie: burnedCalorie == freezed
+      burnedCalorie: null == burnedCalorie
           ? _value.burnedCalorie
           : burnedCalorie // ignore: cast_nullable_to_non_nullable
               as int,
@@ -148,22 +150,20 @@ class _$_HealthByPeriod extends _HealthByPeriod {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_HealthByPeriod &&
-            const DeepCollectionEquality().equals(other.steps, steps) &&
-            const DeepCollectionEquality().equals(other.distance, distance) &&
-            const DeepCollectionEquality()
-                .equals(other.burnedCalorie, burnedCalorie));
+            (identical(other.steps, steps) || other.steps == steps) &&
+            (identical(other.distance, distance) ||
+                other.distance == distance) &&
+            (identical(other.burnedCalorie, burnedCalorie) ||
+                other.burnedCalorie == burnedCalorie));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(steps),
-      const DeepCollectionEquality().hash(distance),
-      const DeepCollectionEquality().hash(burnedCalorie));
+  int get hashCode => Object.hash(runtimeType, steps, distance, burnedCalorie);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_HealthByPeriodCopyWith<_$_HealthByPeriod> get copyWith =>
       __$$_HealthByPeriodCopyWithImpl<_$_HealthByPeriod>(this, _$identity);
 

--- a/lib/domain/user/health/health_info.codegen.freezed.dart
+++ b/lib/domain/user/health/health_info.codegen.freezed.dart
@@ -44,7 +44,8 @@ mixin _$HealthInfo {
 abstract class $HealthInfoCopyWith<$Res> {
   factory $HealthInfoCopyWith(
           HealthInfo value, $Res Function(HealthInfo) then) =
-      _$HealthInfoCopyWithImpl<$Res>;
+      _$HealthInfoCopyWithImpl<$Res, HealthInfo>;
+  @useResult
   $Res call(
       {HealthByPeriod today,
       HealthByPeriod yesterday,
@@ -62,80 +63,87 @@ abstract class $HealthInfoCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$HealthInfoCopyWithImpl<$Res> implements $HealthInfoCopyWith<$Res> {
+class _$HealthInfoCopyWithImpl<$Res, $Val extends HealthInfo>
+    implements $HealthInfoCopyWith<$Res> {
   _$HealthInfoCopyWithImpl(this._value, this._then);
 
-  final HealthInfo _value;
   // ignore: unused_field
-  final $Res Function(HealthInfo) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? today = freezed,
-    Object? yesterday = freezed,
-    Object? week = freezed,
-    Object? month = freezed,
-    Object? updatedAt = freezed,
-    Object? totalSteps = freezed,
-    Object? totalDistance = freezed,
+    Object? today = null,
+    Object? yesterday = null,
+    Object? week = null,
+    Object? month = null,
+    Object? updatedAt = null,
+    Object? totalSteps = null,
+    Object? totalDistance = null,
   }) {
     return _then(_value.copyWith(
-      today: today == freezed
+      today: null == today
           ? _value.today
           : today // ignore: cast_nullable_to_non_nullable
               as HealthByPeriod,
-      yesterday: yesterday == freezed
+      yesterday: null == yesterday
           ? _value.yesterday
           : yesterday // ignore: cast_nullable_to_non_nullable
               as HealthByPeriod,
-      week: week == freezed
+      week: null == week
           ? _value.week
           : week // ignore: cast_nullable_to_non_nullable
               as HealthByPeriod,
-      month: month == freezed
+      month: null == month
           ? _value.month
           : month // ignore: cast_nullable_to_non_nullable
               as HealthByPeriod,
-      updatedAt: updatedAt == freezed
+      updatedAt: null == updatedAt
           ? _value.updatedAt
           : updatedAt // ignore: cast_nullable_to_non_nullable
               as DateTime,
-      totalSteps: totalSteps == freezed
+      totalSteps: null == totalSteps
           ? _value.totalSteps
           : totalSteps // ignore: cast_nullable_to_non_nullable
               as int,
-      totalDistance: totalDistance == freezed
+      totalDistance: null == totalDistance
           ? _value.totalDistance
           : totalDistance // ignore: cast_nullable_to_non_nullable
               as int,
-    ));
+    ) as $Val);
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $HealthByPeriodCopyWith<$Res> get today {
     return $HealthByPeriodCopyWith<$Res>(_value.today, (value) {
-      return _then(_value.copyWith(today: value));
+      return _then(_value.copyWith(today: value) as $Val);
     });
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $HealthByPeriodCopyWith<$Res> get yesterday {
     return $HealthByPeriodCopyWith<$Res>(_value.yesterday, (value) {
-      return _then(_value.copyWith(yesterday: value));
+      return _then(_value.copyWith(yesterday: value) as $Val);
     });
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $HealthByPeriodCopyWith<$Res> get week {
     return $HealthByPeriodCopyWith<$Res>(_value.week, (value) {
-      return _then(_value.copyWith(week: value));
+      return _then(_value.copyWith(week: value) as $Val);
     });
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $HealthByPeriodCopyWith<$Res> get month {
     return $HealthByPeriodCopyWith<$Res>(_value.month, (value) {
-      return _then(_value.copyWith(month: value));
+      return _then(_value.copyWith(month: value) as $Val);
     });
   }
 }
@@ -147,6 +155,7 @@ abstract class _$$_HealthInfoCopyWith<$Res>
           _$_HealthInfo value, $Res Function(_$_HealthInfo) then) =
       __$$_HealthInfoCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {HealthByPeriod today,
       HealthByPeriod yesterday,
@@ -168,51 +177,50 @@ abstract class _$$_HealthInfoCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_HealthInfoCopyWithImpl<$Res> extends _$HealthInfoCopyWithImpl<$Res>
+class __$$_HealthInfoCopyWithImpl<$Res>
+    extends _$HealthInfoCopyWithImpl<$Res, _$_HealthInfo>
     implements _$$_HealthInfoCopyWith<$Res> {
   __$$_HealthInfoCopyWithImpl(
       _$_HealthInfo _value, $Res Function(_$_HealthInfo) _then)
-      : super(_value, (v) => _then(v as _$_HealthInfo));
+      : super(_value, _then);
 
-  @override
-  _$_HealthInfo get _value => super._value as _$_HealthInfo;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? today = freezed,
-    Object? yesterday = freezed,
-    Object? week = freezed,
-    Object? month = freezed,
-    Object? updatedAt = freezed,
-    Object? totalSteps = freezed,
-    Object? totalDistance = freezed,
+    Object? today = null,
+    Object? yesterday = null,
+    Object? week = null,
+    Object? month = null,
+    Object? updatedAt = null,
+    Object? totalSteps = null,
+    Object? totalDistance = null,
   }) {
     return _then(_$_HealthInfo(
-      today: today == freezed
+      today: null == today
           ? _value.today
           : today // ignore: cast_nullable_to_non_nullable
               as HealthByPeriod,
-      yesterday: yesterday == freezed
+      yesterday: null == yesterday
           ? _value.yesterday
           : yesterday // ignore: cast_nullable_to_non_nullable
               as HealthByPeriod,
-      week: week == freezed
+      week: null == week
           ? _value.week
           : week // ignore: cast_nullable_to_non_nullable
               as HealthByPeriod,
-      month: month == freezed
+      month: null == month
           ? _value.month
           : month // ignore: cast_nullable_to_non_nullable
               as HealthByPeriod,
-      updatedAt: updatedAt == freezed
+      updatedAt: null == updatedAt
           ? _value.updatedAt
           : updatedAt // ignore: cast_nullable_to_non_nullable
               as DateTime,
-      totalSteps: totalSteps == freezed
+      totalSteps: null == totalSteps
           ? _value.totalSteps
           : totalSteps // ignore: cast_nullable_to_non_nullable
               as int,
-      totalDistance: totalDistance == freezed
+      totalDistance: null == totalDistance
           ? _value.totalDistance
           : totalDistance // ignore: cast_nullable_to_non_nullable
               as int,
@@ -272,31 +280,27 @@ class _$_HealthInfo extends _HealthInfo {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_HealthInfo &&
-            const DeepCollectionEquality().equals(other.today, today) &&
-            const DeepCollectionEquality().equals(other.yesterday, yesterday) &&
-            const DeepCollectionEquality().equals(other.week, week) &&
-            const DeepCollectionEquality().equals(other.month, month) &&
-            const DeepCollectionEquality().equals(other.updatedAt, updatedAt) &&
-            const DeepCollectionEquality()
-                .equals(other.totalSteps, totalSteps) &&
-            const DeepCollectionEquality()
-                .equals(other.totalDistance, totalDistance));
+            (identical(other.today, today) || other.today == today) &&
+            (identical(other.yesterday, yesterday) ||
+                other.yesterday == yesterday) &&
+            (identical(other.week, week) || other.week == week) &&
+            (identical(other.month, month) || other.month == month) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt) &&
+            (identical(other.totalSteps, totalSteps) ||
+                other.totalSteps == totalSteps) &&
+            (identical(other.totalDistance, totalDistance) ||
+                other.totalDistance == totalDistance));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(today),
-      const DeepCollectionEquality().hash(yesterday),
-      const DeepCollectionEquality().hash(week),
-      const DeepCollectionEquality().hash(month),
-      const DeepCollectionEquality().hash(updatedAt),
-      const DeepCollectionEquality().hash(totalSteps),
-      const DeepCollectionEquality().hash(totalDistance));
+  int get hashCode => Object.hash(runtimeType, today, yesterday, week, month,
+      updatedAt, totalSteps, totalDistance);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_HealthInfoCopyWith<_$_HealthInfo> get copyWith =>
       __$$_HealthInfoCopyWithImpl<_$_HealthInfo>(this, _$identity);
 

--- a/lib/domain/user/pilgrimage/pilgrimage_info.codegen.freezed.dart
+++ b/lib/domain/user/pilgrimage/pilgrimage_info.codegen.freezed.dart
@@ -45,7 +45,8 @@ mixin _$PilgrimageInfo {
 abstract class $PilgrimageInfoCopyWith<$Res> {
   factory $PilgrimageInfoCopyWith(
           PilgrimageInfo value, $Res Function(PilgrimageInfo) then) =
-      _$PilgrimageInfoCopyWithImpl<$Res>;
+      _$PilgrimageInfoCopyWithImpl<$Res, PilgrimageInfo>;
+  @useResult
   $Res call(
       {String id,
       int nowPilgrimageId,
@@ -56,44 +57,46 @@ abstract class $PilgrimageInfoCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$PilgrimageInfoCopyWithImpl<$Res>
+class _$PilgrimageInfoCopyWithImpl<$Res, $Val extends PilgrimageInfo>
     implements $PilgrimageInfoCopyWith<$Res> {
   _$PilgrimageInfoCopyWithImpl(this._value, this._then);
 
-  final PilgrimageInfo _value;
   // ignore: unused_field
-  final $Res Function(PilgrimageInfo) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = freezed,
-    Object? nowPilgrimageId = freezed,
-    Object? lap = freezed,
-    Object? movingDistance = freezed,
-    Object? updatedAt = freezed,
+    Object? id = null,
+    Object? nowPilgrimageId = null,
+    Object? lap = null,
+    Object? movingDistance = null,
+    Object? updatedAt = null,
   }) {
     return _then(_value.copyWith(
-      id: id == freezed
+      id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
               as String,
-      nowPilgrimageId: nowPilgrimageId == freezed
+      nowPilgrimageId: null == nowPilgrimageId
           ? _value.nowPilgrimageId
           : nowPilgrimageId // ignore: cast_nullable_to_non_nullable
               as int,
-      lap: lap == freezed
+      lap: null == lap
           ? _value.lap
           : lap // ignore: cast_nullable_to_non_nullable
               as int,
-      movingDistance: movingDistance == freezed
+      movingDistance: null == movingDistance
           ? _value.movingDistance
           : movingDistance // ignore: cast_nullable_to_non_nullable
               as int,
-      updatedAt: updatedAt == freezed
+      updatedAt: null == updatedAt
           ? _value.updatedAt
           : updatedAt // ignore: cast_nullable_to_non_nullable
               as DateTime,
-    ));
+    ) as $Val);
   }
 }
 
@@ -104,6 +107,7 @@ abstract class _$$_PilgrimageInfoCopyWith<$Res>
           _$_PilgrimageInfo value, $Res Function(_$_PilgrimageInfo) then) =
       __$$_PilgrimageInfoCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {String id,
       int nowPilgrimageId,
@@ -115,41 +119,39 @@ abstract class _$$_PilgrimageInfoCopyWith<$Res>
 
 /// @nodoc
 class __$$_PilgrimageInfoCopyWithImpl<$Res>
-    extends _$PilgrimageInfoCopyWithImpl<$Res>
+    extends _$PilgrimageInfoCopyWithImpl<$Res, _$_PilgrimageInfo>
     implements _$$_PilgrimageInfoCopyWith<$Res> {
   __$$_PilgrimageInfoCopyWithImpl(
       _$_PilgrimageInfo _value, $Res Function(_$_PilgrimageInfo) _then)
-      : super(_value, (v) => _then(v as _$_PilgrimageInfo));
+      : super(_value, _then);
 
-  @override
-  _$_PilgrimageInfo get _value => super._value as _$_PilgrimageInfo;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = freezed,
-    Object? nowPilgrimageId = freezed,
-    Object? lap = freezed,
-    Object? movingDistance = freezed,
-    Object? updatedAt = freezed,
+    Object? id = null,
+    Object? nowPilgrimageId = null,
+    Object? lap = null,
+    Object? movingDistance = null,
+    Object? updatedAt = null,
   }) {
     return _then(_$_PilgrimageInfo(
-      id: id == freezed
+      id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
               as String,
-      nowPilgrimageId: nowPilgrimageId == freezed
+      nowPilgrimageId: null == nowPilgrimageId
           ? _value.nowPilgrimageId
           : nowPilgrimageId // ignore: cast_nullable_to_non_nullable
               as int,
-      lap: lap == freezed
+      lap: null == lap
           ? _value.lap
           : lap // ignore: cast_nullable_to_non_nullable
               as int,
-      movingDistance: movingDistance == freezed
+      movingDistance: null == movingDistance
           ? _value.movingDistance
           : movingDistance // ignore: cast_nullable_to_non_nullable
               as int,
-      updatedAt: updatedAt == freezed
+      updatedAt: null == updatedAt
           ? _value.updatedAt
           : updatedAt // ignore: cast_nullable_to_non_nullable
               as DateTime,
@@ -208,27 +210,24 @@ class _$_PilgrimageInfo extends _PilgrimageInfo {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_PilgrimageInfo &&
-            const DeepCollectionEquality().equals(other.id, id) &&
-            const DeepCollectionEquality()
-                .equals(other.nowPilgrimageId, nowPilgrimageId) &&
-            const DeepCollectionEquality().equals(other.lap, lap) &&
-            const DeepCollectionEquality()
-                .equals(other.movingDistance, movingDistance) &&
-            const DeepCollectionEquality().equals(other.updatedAt, updatedAt));
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.nowPilgrimageId, nowPilgrimageId) ||
+                other.nowPilgrimageId == nowPilgrimageId) &&
+            (identical(other.lap, lap) || other.lap == lap) &&
+            (identical(other.movingDistance, movingDistance) ||
+                other.movingDistance == movingDistance) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt));
   }
 
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(id),
-      const DeepCollectionEquality().hash(nowPilgrimageId),
-      const DeepCollectionEquality().hash(lap),
-      const DeepCollectionEquality().hash(movingDistance),
-      const DeepCollectionEquality().hash(updatedAt));
+      runtimeType, id, nowPilgrimageId, lap, movingDistance, updatedAt);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_PilgrimageInfoCopyWith<_$_PilgrimageInfo> get copyWith =>
       __$$_PilgrimageInfoCopyWithImpl<_$_PilgrimageInfo>(this, _$identity);
 

--- a/lib/domain/user/virtual_pilgrimage_user.codegen.freezed.dart
+++ b/lib/domain/user/virtual_pilgrimage_user.codegen.freezed.dart
@@ -66,7 +66,8 @@ mixin _$VirtualPilgrimageUser {
 abstract class $VirtualPilgrimageUserCopyWith<$Res> {
   factory $VirtualPilgrimageUserCopyWith(VirtualPilgrimageUser value,
           $Res Function(VirtualPilgrimageUser) then) =
-      _$VirtualPilgrimageUserCopyWithImpl<$Res>;
+      _$VirtualPilgrimageUserCopyWithImpl<$Res, VirtualPilgrimageUser>;
+  @useResult
   $Res call(
       {String id,
       String nickname,
@@ -92,96 +93,101 @@ abstract class $VirtualPilgrimageUserCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$VirtualPilgrimageUserCopyWithImpl<$Res>
+class _$VirtualPilgrimageUserCopyWithImpl<$Res,
+        $Val extends VirtualPilgrimageUser>
     implements $VirtualPilgrimageUserCopyWith<$Res> {
   _$VirtualPilgrimageUserCopyWithImpl(this._value, this._then);
 
-  final VirtualPilgrimageUser _value;
   // ignore: unused_field
-  final $Res Function(VirtualPilgrimageUser) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = freezed,
-    Object? nickname = freezed,
-    Object? gender = freezed,
-    Object? birthDay = freezed,
-    Object? email = freezed,
-    Object? userIconUrl = freezed,
-    Object? userStatus = freezed,
-    Object? createdAt = freezed,
-    Object? updatedAt = freezed,
+    Object? id = null,
+    Object? nickname = null,
+    Object? gender = null,
+    Object? birthDay = null,
+    Object? email = null,
+    Object? userIconUrl = null,
+    Object? userStatus = null,
+    Object? createdAt = null,
+    Object? updatedAt = null,
     Object? health = freezed,
-    Object? pilgrimage = freezed,
-    Object? userIcon = freezed,
+    Object? pilgrimage = null,
+    Object? userIcon = null,
   }) {
     return _then(_value.copyWith(
-      id: id == freezed
+      id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
               as String,
-      nickname: nickname == freezed
+      nickname: null == nickname
           ? _value.nickname
           : nickname // ignore: cast_nullable_to_non_nullable
               as String,
-      gender: gender == freezed
+      gender: null == gender
           ? _value.gender
           : gender // ignore: cast_nullable_to_non_nullable
               as Gender,
-      birthDay: birthDay == freezed
+      birthDay: null == birthDay
           ? _value.birthDay
           : birthDay // ignore: cast_nullable_to_non_nullable
               as DateTime,
-      email: email == freezed
+      email: null == email
           ? _value.email
           : email // ignore: cast_nullable_to_non_nullable
               as String,
-      userIconUrl: userIconUrl == freezed
+      userIconUrl: null == userIconUrl
           ? _value.userIconUrl
           : userIconUrl // ignore: cast_nullable_to_non_nullable
               as String,
-      userStatus: userStatus == freezed
+      userStatus: null == userStatus
           ? _value.userStatus
           : userStatus // ignore: cast_nullable_to_non_nullable
               as UserStatus,
-      createdAt: createdAt == freezed
+      createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
               as DateTime,
-      updatedAt: updatedAt == freezed
+      updatedAt: null == updatedAt
           ? _value.updatedAt
           : updatedAt // ignore: cast_nullable_to_non_nullable
               as DateTime,
-      health: health == freezed
+      health: freezed == health
           ? _value.health
           : health // ignore: cast_nullable_to_non_nullable
               as HealthInfo?,
-      pilgrimage: pilgrimage == freezed
+      pilgrimage: null == pilgrimage
           ? _value.pilgrimage
           : pilgrimage // ignore: cast_nullable_to_non_nullable
               as PilgrimageInfo,
-      userIcon: userIcon == freezed
+      userIcon: null == userIcon
           ? _value.userIcon
           : userIcon // ignore: cast_nullable_to_non_nullable
               as BitmapDescriptor,
-    ));
+    ) as $Val);
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $HealthInfoCopyWith<$Res>? get health {
     if (_value.health == null) {
       return null;
     }
 
     return $HealthInfoCopyWith<$Res>(_value.health!, (value) {
-      return _then(_value.copyWith(health: value));
+      return _then(_value.copyWith(health: value) as $Val);
     });
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $PilgrimageInfoCopyWith<$Res> get pilgrimage {
     return $PilgrimageInfoCopyWith<$Res>(_value.pilgrimage, (value) {
-      return _then(_value.copyWith(pilgrimage: value));
+      return _then(_value.copyWith(pilgrimage: value) as $Val);
     });
   }
 }
@@ -193,6 +199,7 @@ abstract class _$$_VirtualPilgrimageUserCopyWith<$Res>
           $Res Function(_$_VirtualPilgrimageUser) then) =
       __$$_VirtualPilgrimageUserCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {String id,
       String nickname,
@@ -221,77 +228,74 @@ abstract class _$$_VirtualPilgrimageUserCopyWith<$Res>
 
 /// @nodoc
 class __$$_VirtualPilgrimageUserCopyWithImpl<$Res>
-    extends _$VirtualPilgrimageUserCopyWithImpl<$Res>
+    extends _$VirtualPilgrimageUserCopyWithImpl<$Res, _$_VirtualPilgrimageUser>
     implements _$$_VirtualPilgrimageUserCopyWith<$Res> {
   __$$_VirtualPilgrimageUserCopyWithImpl(_$_VirtualPilgrimageUser _value,
       $Res Function(_$_VirtualPilgrimageUser) _then)
-      : super(_value, (v) => _then(v as _$_VirtualPilgrimageUser));
+      : super(_value, _then);
 
-  @override
-  _$_VirtualPilgrimageUser get _value =>
-      super._value as _$_VirtualPilgrimageUser;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = freezed,
-    Object? nickname = freezed,
-    Object? gender = freezed,
-    Object? birthDay = freezed,
-    Object? email = freezed,
-    Object? userIconUrl = freezed,
-    Object? userStatus = freezed,
-    Object? createdAt = freezed,
-    Object? updatedAt = freezed,
+    Object? id = null,
+    Object? nickname = null,
+    Object? gender = null,
+    Object? birthDay = null,
+    Object? email = null,
+    Object? userIconUrl = null,
+    Object? userStatus = null,
+    Object? createdAt = null,
+    Object? updatedAt = null,
     Object? health = freezed,
-    Object? pilgrimage = freezed,
-    Object? userIcon = freezed,
+    Object? pilgrimage = null,
+    Object? userIcon = null,
   }) {
     return _then(_$_VirtualPilgrimageUser(
-      id: id == freezed
+      id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
               as String,
-      nickname: nickname == freezed
+      nickname: null == nickname
           ? _value.nickname
           : nickname // ignore: cast_nullable_to_non_nullable
               as String,
-      gender: gender == freezed
+      gender: null == gender
           ? _value.gender
           : gender // ignore: cast_nullable_to_non_nullable
               as Gender,
-      birthDay: birthDay == freezed
+      birthDay: null == birthDay
           ? _value.birthDay
           : birthDay // ignore: cast_nullable_to_non_nullable
               as DateTime,
-      email: email == freezed
+      email: null == email
           ? _value.email
           : email // ignore: cast_nullable_to_non_nullable
               as String,
-      userIconUrl: userIconUrl == freezed
+      userIconUrl: null == userIconUrl
           ? _value.userIconUrl
           : userIconUrl // ignore: cast_nullable_to_non_nullable
               as String,
-      userStatus: userStatus == freezed
+      userStatus: null == userStatus
           ? _value.userStatus
           : userStatus // ignore: cast_nullable_to_non_nullable
               as UserStatus,
-      createdAt: createdAt == freezed
+      createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
               as DateTime,
-      updatedAt: updatedAt == freezed
+      updatedAt: null == updatedAt
           ? _value.updatedAt
           : updatedAt // ignore: cast_nullable_to_non_nullable
               as DateTime,
-      health: health == freezed
+      health: freezed == health
           ? _value.health
           : health // ignore: cast_nullable_to_non_nullable
               as HealthInfo?,
-      pilgrimage: pilgrimage == freezed
+      pilgrimage: null == pilgrimage
           ? _value.pilgrimage
           : pilgrimage // ignore: cast_nullable_to_non_nullable
               as PilgrimageInfo,
-      userIcon: userIcon == freezed
+      userIcon: null == userIcon
           ? _value.userIcon
           : userIcon // ignore: cast_nullable_to_non_nullable
               as BitmapDescriptor,
@@ -395,42 +399,48 @@ class _$_VirtualPilgrimageUser extends _VirtualPilgrimageUser {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_VirtualPilgrimageUser &&
-            const DeepCollectionEquality().equals(other.id, id) &&
-            const DeepCollectionEquality().equals(other.nickname, nickname) &&
-            const DeepCollectionEquality().equals(other.gender, gender) &&
-            const DeepCollectionEquality().equals(other.birthDay, birthDay) &&
-            const DeepCollectionEquality().equals(other.email, email) &&
-            const DeepCollectionEquality()
-                .equals(other.userIconUrl, userIconUrl) &&
-            const DeepCollectionEquality()
-                .equals(other.userStatus, userStatus) &&
-            const DeepCollectionEquality().equals(other.createdAt, createdAt) &&
-            const DeepCollectionEquality().equals(other.updatedAt, updatedAt) &&
-            const DeepCollectionEquality().equals(other.health, health) &&
-            const DeepCollectionEquality()
-                .equals(other.pilgrimage, pilgrimage) &&
-            const DeepCollectionEquality().equals(other.userIcon, userIcon));
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.nickname, nickname) ||
+                other.nickname == nickname) &&
+            (identical(other.gender, gender) || other.gender == gender) &&
+            (identical(other.birthDay, birthDay) ||
+                other.birthDay == birthDay) &&
+            (identical(other.email, email) || other.email == email) &&
+            (identical(other.userIconUrl, userIconUrl) ||
+                other.userIconUrl == userIconUrl) &&
+            (identical(other.userStatus, userStatus) ||
+                other.userStatus == userStatus) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt) &&
+            (identical(other.health, health) || other.health == health) &&
+            (identical(other.pilgrimage, pilgrimage) ||
+                other.pilgrimage == pilgrimage) &&
+            (identical(other.userIcon, userIcon) ||
+                other.userIcon == userIcon));
   }
 
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      const DeepCollectionEquality().hash(id),
-      const DeepCollectionEquality().hash(nickname),
-      const DeepCollectionEquality().hash(gender),
-      const DeepCollectionEquality().hash(birthDay),
-      const DeepCollectionEquality().hash(email),
-      const DeepCollectionEquality().hash(userIconUrl),
-      const DeepCollectionEquality().hash(userStatus),
-      const DeepCollectionEquality().hash(createdAt),
-      const DeepCollectionEquality().hash(updatedAt),
-      const DeepCollectionEquality().hash(health),
-      const DeepCollectionEquality().hash(pilgrimage),
-      const DeepCollectionEquality().hash(userIcon));
+      id,
+      nickname,
+      gender,
+      birthDay,
+      email,
+      userIconUrl,
+      userStatus,
+      createdAt,
+      updatedAt,
+      health,
+      pilgrimage,
+      userIcon);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_VirtualPilgrimageUserCopyWith<_$_VirtualPilgrimageUser> get copyWith =>
       __$$_VirtualPilgrimageUserCopyWithImpl<_$_VirtualPilgrimageUser>(
           this, _$identity);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,8 +32,8 @@ class _App extends ConsumerWidget {
     final router = ref.watch(routerProvider);
     final firebaseAuth = ref.watch(firebaseAuthProvider);
     final analytics = ref.read(analyticsProvider);
-    final userState = ref.watch(userStateProvider.state);
-    final loginState = ref.watch(loginStateProvider.state);
+    final userState = ref.watch(userStateProvider.notifier);
+    final loginState = ref.watch(loginStateProvider.notifier);
     // final userIconRepository = ref.read(userIconRepositoryProvider);
 
     // Firebaseへのログインがキャッシュされていれば

--- a/lib/model/form_model.codegen.freezed.dart
+++ b/lib/model/form_model.codegen.freezed.dart
@@ -30,7 +30,8 @@ mixin _$FormModel {
 /// @nodoc
 abstract class $FormModelCopyWith<$Res> {
   factory $FormModelCopyWith(FormModel value, $Res Function(FormModel) then) =
-      _$FormModelCopyWithImpl<$Res>;
+      _$FormModelCopyWithImpl<$Res, FormModel>;
+  @useResult
   $Res call(
       {Validator validator,
       TextEditingController controller,
@@ -40,43 +41,46 @@ abstract class $FormModelCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$FormModelCopyWithImpl<$Res> implements $FormModelCopyWith<$Res> {
+class _$FormModelCopyWithImpl<$Res, $Val extends FormModel>
+    implements $FormModelCopyWith<$Res> {
   _$FormModelCopyWithImpl(this._value, this._then);
 
-  final FormModel _value;
   // ignore: unused_field
-  final $Res Function(FormModel) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? validator = freezed,
-    Object? controller = freezed,
-    Object? focusNode = freezed,
-    Object? hasEdited = freezed,
-    Object? externalErrors = freezed,
+    Object? validator = null,
+    Object? controller = null,
+    Object? focusNode = null,
+    Object? hasEdited = null,
+    Object? externalErrors = null,
   }) {
     return _then(_value.copyWith(
-      validator: validator == freezed
+      validator: null == validator
           ? _value.validator
           : validator // ignore: cast_nullable_to_non_nullable
               as Validator,
-      controller: controller == freezed
+      controller: null == controller
           ? _value.controller
           : controller // ignore: cast_nullable_to_non_nullable
               as TextEditingController,
-      focusNode: focusNode == freezed
+      focusNode: null == focusNode
           ? _value.focusNode
           : focusNode // ignore: cast_nullable_to_non_nullable
               as FocusNode,
-      hasEdited: hasEdited == freezed
+      hasEdited: null == hasEdited
           ? _value.hasEdited
           : hasEdited // ignore: cast_nullable_to_non_nullable
               as bool,
-      externalErrors: externalErrors == freezed
+      externalErrors: null == externalErrors
           ? _value.externalErrors
           : externalErrors // ignore: cast_nullable_to_non_nullable
               as List<String>,
-    ));
+    ) as $Val);
   }
 }
 
@@ -86,6 +90,7 @@ abstract class _$$_FormModelCopyWith<$Res> implements $FormModelCopyWith<$Res> {
           _$_FormModel value, $Res Function(_$_FormModel) then) =
       __$$_FormModelCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {Validator validator,
       TextEditingController controller,
@@ -95,41 +100,40 @@ abstract class _$$_FormModelCopyWith<$Res> implements $FormModelCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_FormModelCopyWithImpl<$Res> extends _$FormModelCopyWithImpl<$Res>
+class __$$_FormModelCopyWithImpl<$Res>
+    extends _$FormModelCopyWithImpl<$Res, _$_FormModel>
     implements _$$_FormModelCopyWith<$Res> {
   __$$_FormModelCopyWithImpl(
       _$_FormModel _value, $Res Function(_$_FormModel) _then)
-      : super(_value, (v) => _then(v as _$_FormModel));
+      : super(_value, _then);
 
-  @override
-  _$_FormModel get _value => super._value as _$_FormModel;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? validator = freezed,
-    Object? controller = freezed,
-    Object? focusNode = freezed,
-    Object? hasEdited = freezed,
-    Object? externalErrors = freezed,
+    Object? validator = null,
+    Object? controller = null,
+    Object? focusNode = null,
+    Object? hasEdited = null,
+    Object? externalErrors = null,
   }) {
     return _then(_$_FormModel(
-      validator: validator == freezed
+      validator: null == validator
           ? _value.validator
           : validator // ignore: cast_nullable_to_non_nullable
               as Validator,
-      controller: controller == freezed
+      controller: null == controller
           ? _value.controller
           : controller // ignore: cast_nullable_to_non_nullable
               as TextEditingController,
-      focusNode: focusNode == freezed
+      focusNode: null == focusNode
           ? _value.focusNode
           : focusNode // ignore: cast_nullable_to_non_nullable
               as FocusNode,
-      hasEdited: hasEdited == freezed
+      hasEdited: null == hasEdited
           ? _value.hasEdited
           : hasEdited // ignore: cast_nullable_to_non_nullable
               as bool,
-      externalErrors: externalErrors == freezed
+      externalErrors: null == externalErrors
           ? _value._externalErrors
           : externalErrors // ignore: cast_nullable_to_non_nullable
               as List<String>,
@@ -178,25 +182,23 @@ class _$_FormModel extends _FormModel {
             other is _$_FormModel &&
             (identical(other.validator, validator) ||
                 other.validator == validator) &&
-            const DeepCollectionEquality()
-                .equals(other.controller, controller) &&
-            const DeepCollectionEquality().equals(other.focusNode, focusNode) &&
-            const DeepCollectionEquality().equals(other.hasEdited, hasEdited) &&
+            (identical(other.controller, controller) ||
+                other.controller == controller) &&
+            (identical(other.focusNode, focusNode) ||
+                other.focusNode == focusNode) &&
+            (identical(other.hasEdited, hasEdited) ||
+                other.hasEdited == hasEdited) &&
             const DeepCollectionEquality()
                 .equals(other._externalErrors, _externalErrors));
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      validator,
-      const DeepCollectionEquality().hash(controller),
-      const DeepCollectionEquality().hash(focusNode),
-      const DeepCollectionEquality().hash(hasEdited),
-      const DeepCollectionEquality().hash(_externalErrors));
+  int get hashCode => Object.hash(runtimeType, validator, controller, focusNode,
+      hasEdited, const DeepCollectionEquality().hash(_externalErrors));
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_FormModelCopyWith<_$_FormModel> get copyWith =>
       __$$_FormModelCopyWithImpl<_$_FormModel>(this, _$identity);
 }

--- a/lib/model/google_map_model.codegen.dart
+++ b/lib/model/google_map_model.codegen.dart
@@ -17,22 +17,4 @@ class GoogleMapModel with _$GoogleMapModel {
   const GoogleMapModel._();
 
   void onMapCreated(GoogleMapController controller) => this.controller.complete(controller);
-
-  // ignore: prefer_constructors_over_static_methods
-  static GoogleMapModel initialize() => GoogleMapModel(
-        controller: Completer(),
-        // FIXME: 適当に埋めているだけであるため、firestore or cache からお遍路の情報を引っ張ってくるようにする
-        markers: {
-          const Marker(
-            markerId: MarkerId('霊山寺'),
-            position: LatLng(34.15944444, 134.503),
-            infoWindow: InfoWindow(title: '霊峰寺', snippet: '1箇所目'),
-          ),
-          const Marker(
-            markerId: MarkerId('極楽寺'),
-            position: LatLng(34.15565, 134.490347),
-            infoWindow: InfoWindow(title: '極楽寺', snippet: '2箇所目'),
-          ),
-        },
-      );
 }

--- a/lib/model/google_map_model.codegen.freezed.dart
+++ b/lib/model/google_map_model.codegen.freezed.dart
@@ -30,7 +30,8 @@ mixin _$GoogleMapModel {
 abstract class $GoogleMapModelCopyWith<$Res> {
   factory $GoogleMapModelCopyWith(
           GoogleMapModel value, $Res Function(GoogleMapModel) then) =
-      _$GoogleMapModelCopyWithImpl<$Res>;
+      _$GoogleMapModelCopyWithImpl<$Res, GoogleMapModel>;
+  @useResult
   $Res call(
       {Completer<GoogleMapController> controller,
       Set<Marker> markers,
@@ -38,34 +39,36 @@ abstract class $GoogleMapModelCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$GoogleMapModelCopyWithImpl<$Res>
+class _$GoogleMapModelCopyWithImpl<$Res, $Val extends GoogleMapModel>
     implements $GoogleMapModelCopyWith<$Res> {
   _$GoogleMapModelCopyWithImpl(this._value, this._then);
 
-  final GoogleMapModel _value;
   // ignore: unused_field
-  final $Res Function(GoogleMapModel) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? controller = freezed,
-    Object? markers = freezed,
-    Object? polylines = freezed,
+    Object? controller = null,
+    Object? markers = null,
+    Object? polylines = null,
   }) {
     return _then(_value.copyWith(
-      controller: controller == freezed
+      controller: null == controller
           ? _value.controller
           : controller // ignore: cast_nullable_to_non_nullable
               as Completer<GoogleMapController>,
-      markers: markers == freezed
+      markers: null == markers
           ? _value.markers
           : markers // ignore: cast_nullable_to_non_nullable
               as Set<Marker>,
-      polylines: polylines == freezed
+      polylines: null == polylines
           ? _value.polylines
           : polylines // ignore: cast_nullable_to_non_nullable
               as Set<Polyline>,
-    ));
+    ) as $Val);
   }
 }
 
@@ -76,6 +79,7 @@ abstract class _$$_GoogleMapModelCopyWith<$Res>
           _$_GoogleMapModel value, $Res Function(_$_GoogleMapModel) then) =
       __$$_GoogleMapModelCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {Completer<GoogleMapController> controller,
       Set<Marker> markers,
@@ -84,31 +88,29 @@ abstract class _$$_GoogleMapModelCopyWith<$Res>
 
 /// @nodoc
 class __$$_GoogleMapModelCopyWithImpl<$Res>
-    extends _$GoogleMapModelCopyWithImpl<$Res>
+    extends _$GoogleMapModelCopyWithImpl<$Res, _$_GoogleMapModel>
     implements _$$_GoogleMapModelCopyWith<$Res> {
   __$$_GoogleMapModelCopyWithImpl(
       _$_GoogleMapModel _value, $Res Function(_$_GoogleMapModel) _then)
-      : super(_value, (v) => _then(v as _$_GoogleMapModel));
+      : super(_value, _then);
 
-  @override
-  _$_GoogleMapModel get _value => super._value as _$_GoogleMapModel;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? controller = freezed,
-    Object? markers = freezed,
-    Object? polylines = freezed,
+    Object? controller = null,
+    Object? markers = null,
+    Object? polylines = null,
   }) {
     return _then(_$_GoogleMapModel(
-      controller: controller == freezed
+      controller: null == controller
           ? _value.controller
           : controller // ignore: cast_nullable_to_non_nullable
               as Completer<GoogleMapController>,
-      markers: markers == freezed
+      markers: null == markers
           ? _value._markers
           : markers // ignore: cast_nullable_to_non_nullable
               as Set<Marker>,
-      polylines: polylines == freezed
+      polylines: null == polylines
           ? _value._polylines
           : polylines // ignore: cast_nullable_to_non_nullable
               as Set<Polyline>,
@@ -155,8 +157,8 @@ class _$_GoogleMapModel extends _GoogleMapModel {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_GoogleMapModel &&
-            const DeepCollectionEquality()
-                .equals(other.controller, controller) &&
+            (identical(other.controller, controller) ||
+                other.controller == controller) &&
             const DeepCollectionEquality().equals(other._markers, _markers) &&
             const DeepCollectionEquality()
                 .equals(other._polylines, _polylines));
@@ -165,12 +167,13 @@ class _$_GoogleMapModel extends _GoogleMapModel {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      const DeepCollectionEquality().hash(controller),
+      controller,
       const DeepCollectionEquality().hash(_markers),
       const DeepCollectionEquality().hash(_polylines));
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_GoogleMapModelCopyWith<_$_GoogleMapModel> get copyWith =>
       __$$_GoogleMapModelCopyWithImpl<_$_GoogleMapModel>(this, _$identity);
 }

--- a/lib/model/radio_button_model.codegen.freezed.dart
+++ b/lib/model/radio_button_model.codegen.freezed.dart
@@ -28,33 +28,37 @@ mixin _$ColorModel {
 abstract class $ColorModelCopyWith<$Res> {
   factory $ColorModelCopyWith(
           ColorModel value, $Res Function(ColorModel) then) =
-      _$ColorModelCopyWithImpl<$Res>;
+      _$ColorModelCopyWithImpl<$Res, ColorModel>;
+  @useResult
   $Res call({Color lightColor, Color darkColor});
 }
 
 /// @nodoc
-class _$ColorModelCopyWithImpl<$Res> implements $ColorModelCopyWith<$Res> {
+class _$ColorModelCopyWithImpl<$Res, $Val extends ColorModel>
+    implements $ColorModelCopyWith<$Res> {
   _$ColorModelCopyWithImpl(this._value, this._then);
 
-  final ColorModel _value;
   // ignore: unused_field
-  final $Res Function(ColorModel) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? lightColor = freezed,
-    Object? darkColor = freezed,
+    Object? lightColor = null,
+    Object? darkColor = null,
   }) {
     return _then(_value.copyWith(
-      lightColor: lightColor == freezed
+      lightColor: null == lightColor
           ? _value.lightColor
           : lightColor // ignore: cast_nullable_to_non_nullable
               as Color,
-      darkColor: darkColor == freezed
+      darkColor: null == darkColor
           ? _value.darkColor
           : darkColor // ignore: cast_nullable_to_non_nullable
               as Color,
-    ));
+    ) as $Val);
   }
 }
 
@@ -65,30 +69,30 @@ abstract class _$$_ColorModelCopyWith<$Res>
           _$_ColorModel value, $Res Function(_$_ColorModel) then) =
       __$$_ColorModelCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call({Color lightColor, Color darkColor});
 }
 
 /// @nodoc
-class __$$_ColorModelCopyWithImpl<$Res> extends _$ColorModelCopyWithImpl<$Res>
+class __$$_ColorModelCopyWithImpl<$Res>
+    extends _$ColorModelCopyWithImpl<$Res, _$_ColorModel>
     implements _$$_ColorModelCopyWith<$Res> {
   __$$_ColorModelCopyWithImpl(
       _$_ColorModel _value, $Res Function(_$_ColorModel) _then)
-      : super(_value, (v) => _then(v as _$_ColorModel));
+      : super(_value, _then);
 
-  @override
-  _$_ColorModel get _value => super._value as _$_ColorModel;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? lightColor = freezed,
-    Object? darkColor = freezed,
+    Object? lightColor = null,
+    Object? darkColor = null,
   }) {
     return _then(_$_ColorModel(
-      lightColor: lightColor == freezed
+      lightColor: null == lightColor
           ? _value.lightColor
           : lightColor // ignore: cast_nullable_to_non_nullable
               as Color,
-      darkColor: darkColor == freezed
+      darkColor: null == darkColor
           ? _value.darkColor
           : darkColor // ignore: cast_nullable_to_non_nullable
               as Color,
@@ -117,19 +121,18 @@ class _$_ColorModel extends _ColorModel {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_ColorModel &&
-            const DeepCollectionEquality()
-                .equals(other.lightColor, lightColor) &&
-            const DeepCollectionEquality().equals(other.darkColor, darkColor));
+            (identical(other.lightColor, lightColor) ||
+                other.lightColor == lightColor) &&
+            (identical(other.darkColor, darkColor) ||
+                other.darkColor == darkColor));
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(lightColor),
-      const DeepCollectionEquality().hash(darkColor));
+  int get hashCode => Object.hash(runtimeType, lightColor, darkColor);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_ColorModelCopyWith<_$_ColorModel> get copyWith =>
       __$$_ColorModelCopyWithImpl<_$_ColorModel>(this, _$identity);
 }
@@ -168,7 +171,8 @@ mixin _$RadioButtonModel<T> {
 abstract class $RadioButtonModelCopyWith<T, $Res> {
   factory $RadioButtonModelCopyWith(
           RadioButtonModel<T> value, $Res Function(RadioButtonModel<T>) then) =
-      _$RadioButtonModelCopyWithImpl<T, $Res>;
+      _$RadioButtonModelCopyWithImpl<T, $Res, RadioButtonModel<T>>;
+  @useResult
   $Res call(
       {List<FocusNode> focusNodes,
       List<String> titles,
@@ -178,44 +182,46 @@ abstract class $RadioButtonModelCopyWith<T, $Res> {
 }
 
 /// @nodoc
-class _$RadioButtonModelCopyWithImpl<T, $Res>
+class _$RadioButtonModelCopyWithImpl<T, $Res, $Val extends RadioButtonModel<T>>
     implements $RadioButtonModelCopyWith<T, $Res> {
   _$RadioButtonModelCopyWithImpl(this._value, this._then);
 
-  final RadioButtonModel<T> _value;
   // ignore: unused_field
-  final $Res Function(RadioButtonModel<T>) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? focusNodes = freezed,
-    Object? titles = freezed,
-    Object? values = freezed,
-    Object? selectedValue = freezed,
-    Object? colors = freezed,
+    Object? focusNodes = null,
+    Object? titles = null,
+    Object? values = null,
+    Object? selectedValue = null,
+    Object? colors = null,
   }) {
     return _then(_value.copyWith(
-      focusNodes: focusNodes == freezed
+      focusNodes: null == focusNodes
           ? _value.focusNodes
           : focusNodes // ignore: cast_nullable_to_non_nullable
               as List<FocusNode>,
-      titles: titles == freezed
+      titles: null == titles
           ? _value.titles
           : titles // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      values: values == freezed
+      values: null == values
           ? _value.values
           : values // ignore: cast_nullable_to_non_nullable
               as List<T>,
-      selectedValue: selectedValue == freezed
+      selectedValue: null == selectedValue
           ? _value.selectedValue
           : selectedValue // ignore: cast_nullable_to_non_nullable
               as T,
-      colors: colors == freezed
+      colors: null == colors
           ? _value.colors
           : colors // ignore: cast_nullable_to_non_nullable
               as List<ColorModel>,
-    ));
+    ) as $Val);
   }
 }
 
@@ -226,6 +232,7 @@ abstract class _$$_RadioButtonModelCopyWith<T, $Res>
           $Res Function(_$_RadioButtonModel<T>) then) =
       __$$_RadioButtonModelCopyWithImpl<T, $Res>;
   @override
+  @useResult
   $Res call(
       {List<FocusNode> focusNodes,
       List<String> titles,
@@ -236,41 +243,39 @@ abstract class _$$_RadioButtonModelCopyWith<T, $Res>
 
 /// @nodoc
 class __$$_RadioButtonModelCopyWithImpl<T, $Res>
-    extends _$RadioButtonModelCopyWithImpl<T, $Res>
+    extends _$RadioButtonModelCopyWithImpl<T, $Res, _$_RadioButtonModel<T>>
     implements _$$_RadioButtonModelCopyWith<T, $Res> {
   __$$_RadioButtonModelCopyWithImpl(_$_RadioButtonModel<T> _value,
       $Res Function(_$_RadioButtonModel<T>) _then)
-      : super(_value, (v) => _then(v as _$_RadioButtonModel<T>));
+      : super(_value, _then);
 
-  @override
-  _$_RadioButtonModel<T> get _value => super._value as _$_RadioButtonModel<T>;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? focusNodes = freezed,
-    Object? titles = freezed,
-    Object? values = freezed,
-    Object? selectedValue = freezed,
-    Object? colors = freezed,
+    Object? focusNodes = null,
+    Object? titles = null,
+    Object? values = null,
+    Object? selectedValue = null,
+    Object? colors = null,
   }) {
     return _then(_$_RadioButtonModel<T>(
-      focusNodes: focusNodes == freezed
+      focusNodes: null == focusNodes
           ? _value._focusNodes
           : focusNodes // ignore: cast_nullable_to_non_nullable
               as List<FocusNode>,
-      titles: titles == freezed
+      titles: null == titles
           ? _value._titles
           : titles // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      values: values == freezed
+      values: null == values
           ? _value._values
           : values // ignore: cast_nullable_to_non_nullable
               as List<T>,
-      selectedValue: selectedValue == freezed
+      selectedValue: null == selectedValue
           ? _value.selectedValue
           : selectedValue // ignore: cast_nullable_to_non_nullable
               as T,
-      colors: colors == freezed
+      colors: null == colors
           ? _value._colors
           : colors // ignore: cast_nullable_to_non_nullable
               as List<ColorModel>,
@@ -356,6 +361,7 @@ class _$_RadioButtonModel<T> extends _RadioButtonModel<T> {
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_RadioButtonModelCopyWith<T, _$_RadioButtonModel<T>> get copyWith =>
       __$$_RadioButtonModelCopyWithImpl<T, _$_RadioButtonModel<T>>(
           this, _$identity);

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -89,31 +89,26 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>(
         },
       ),
     ],
-    redirect: (state) {
+    redirect: (BuildContext context, GoRouterState state) {
       ref.read(loggerProvider).d(state.location);
+
       // サインイン状態によって遷移先を変える
       final loginState = ref.watch(loginStateProvider);
       if (loginState == null) {
-        if (state.location != RouterPath.signIn) {
-          return RouterPath.signIn;
-        }
-      } else {
-        switch (loginState) {
-          // ユーザが作成済みの時
-          // 基本的にはここにページ遷移を記載する
-          case UserStatus.created:
-            return null;
-          // ユーザ情報が登録途中の時
-          case UserStatus.temporary:
-            if (state.location != RouterPath.registration) {
-              return RouterPath.registration;
-            }
-            break;
-          // 削除済みの時
-          case UserStatus.deleted:
-            // TODO(s14t284): Handle this case.
-            break;
-        }
+        return RouterPath.signIn;
+      }
+      switch (loginState) {
+        // ユーザが作成済みの時
+        // 基本的にはここに遷移してくるので、遷移先に与えられた箇所に移動するよう null を返す
+        case UserStatus.created:
+          return null;
+        // ユーザ情報が登録途中の時
+        case UserStatus.temporary:
+          return RouterPath.registration;
+        // 削除済みの時
+        case UserStatus.deleted:
+          // TODO(s14t284): Handle this case.
+          break;
       }
 
       return null;

--- a/lib/ui/components/atoms/primary_button.dart
+++ b/lib/ui/components/atoms/primary_button.dart
@@ -22,9 +22,8 @@ class PrimaryButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return ElevatedButton(
       style: ElevatedButton.styleFrom(
-        // MEMO: Flutter3.3からは primary = backgroundColor, onPrimary = foregroundColor に変更されていることに注意
-        primary: Theme.of(context).colorScheme.primary,
-        onPrimary: Theme.of(context).colorScheme.onPrimary,
+        backgroundColor: Theme.of(context).colorScheme.primary,
+        foregroundColor: Theme.of(context).colorScheme.onPrimary,
         minimumSize: const Size(48, 48),
         fixedSize: buttonSize,
         maximumSize: Size(MediaQuery.of(context).size.width - 24, 96),

--- a/lib/ui/components/atoms/secondary_button.dart
+++ b/lib/ui/components/atoms/secondary_button.dart
@@ -22,9 +22,8 @@ class SecondaryButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return ElevatedButton(
       style: ElevatedButton.styleFrom(
-        // MEMO: Flutter3.3からは primary = backgroundColor, onPrimary = foregroundColor に変更されていることに注意
-        primary: Theme.of(context).colorScheme.secondaryContainer,
-        onPrimary: Theme.of(context).colorScheme.onSecondaryContainer,
+        backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
+        foregroundColor: Theme.of(context).colorScheme.onSecondaryContainer,
         minimumSize: const Size(48, 48),
         fixedSize: buttonSize,
         maximumSize: Size(MediaQuery.of(context).size.width - 24, 96),

--- a/lib/ui/components/bottom_navigation.dart
+++ b/lib/ui/components/bottom_navigation.dart
@@ -49,7 +49,7 @@ class BottomNavigation extends ConsumerWidget {
         pageTypeNotifier.state = pageType;
         analytics.logEvent(
           eventName: AnalyticsEvent.pressedBottomNavigation,
-          parameters: {'pageType': pageType},
+          parameters: {'pageType': pageType.name},
         );
         switch (pageType) {
           case PageType.temple:

--- a/lib/ui/components/molecules/my_drawer.dart
+++ b/lib/ui/components/molecules/my_drawer.dart
@@ -88,8 +88,8 @@ class MyDrawer extends ConsumerWidget {
     Navigator.of(context).pop();
     await ref.read(analyticsProvider).logEvent(eventName: AnalyticsEvent.logout);
     await ref.read(signInUsecaseProvider).logout();
-    ref.read(userStateProvider.state).state = null;
+    ref.read(userStateProvider.notifier).state = null;
     // loginState を変更するとページが遷移するので更新順を後ろにしている
-    ref.read(loginStateProvider.state).state = null;
+    ref.read(loginStateProvider.notifier).state = null;
   }
 }

--- a/lib/ui/pages/home/home_presenter.dart
+++ b/lib/ui/pages/home/home_presenter.dart
@@ -29,7 +29,9 @@ class HomePresenter extends StateNotifier<HomeState> {
     _crashlytics = _ref.read(firebaseCrashlyticsProvider);
     _templeRepository = _ref.read(templeRepositoryProvider);
     _userStateNotifier = _ref.read(userStateProvider.notifier);
-    _ref.read(pageTypeProvider.notifier).state = PageType.home;
+    _ref.read(pageTypeProvider.notifier).addListener((state) {
+      state = PageType.home;
+    });
     initialize();
   }
 

--- a/lib/ui/pages/home/home_presenter.dart
+++ b/lib/ui/pages/home/home_presenter.dart
@@ -14,7 +14,6 @@ import 'package:virtualpilgrimage/domain/user/health/update_health_usecase.dart'
 import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
 import 'package:virtualpilgrimage/infrastructure/firebase/firebase_crashlytics_provider.dart';
 import 'package:virtualpilgrimage/logger.dart';
-import 'package:virtualpilgrimage/ui/components/bottom_navigation.dart';
 
 import 'home_state.codegen.dart';
 
@@ -29,9 +28,6 @@ class HomePresenter extends StateNotifier<HomeState> {
     _crashlytics = _ref.read(firebaseCrashlyticsProvider);
     _templeRepository = _ref.read(templeRepositoryProvider);
     _userStateNotifier = _ref.read(userStateProvider.notifier);
-    _ref.read(pageTypeProvider.notifier).addListener((state) {
-      state = PageType.home;
-    });
     initialize();
   }
 

--- a/lib/ui/pages/home/home_state.codegen.dart
+++ b/lib/ui/pages/home/home_state.codegen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:virtualpilgrimage/model/google_map_model.codegen.dart';
@@ -29,7 +31,7 @@ class HomeState with _$HomeState {
 
   // ignore: prefer_constructors_over_static_methods
   static HomeState initialize() => HomeState(
-        googleMap: GoogleMapModel.initialize(),
+        googleMap: GoogleMapModel(controller: Completer()),
         initialCameraPosition: _initialCameraPosition,
       );
 

--- a/lib/ui/pages/home/home_state.codegen.freezed.dart
+++ b/lib/ui/pages/home/home_state.codegen.freezed.dart
@@ -31,7 +31,8 @@ mixin _$HomeState {
 /// @nodoc
 abstract class $HomeStateCopyWith<$Res> {
   factory $HomeStateCopyWith(HomeState value, $Res Function(HomeState) then) =
-      _$HomeStateCopyWithImpl<$Res>;
+      _$HomeStateCopyWithImpl<$Res, HomeState>;
+  @useResult
   $Res call(
       {GoogleMapModel googleMap,
       CameraPosition initialCameraPosition,
@@ -43,49 +44,53 @@ abstract class $HomeStateCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$HomeStateCopyWithImpl<$Res> implements $HomeStateCopyWith<$Res> {
+class _$HomeStateCopyWithImpl<$Res, $Val extends HomeState>
+    implements $HomeStateCopyWith<$Res> {
   _$HomeStateCopyWithImpl(this._value, this._then);
 
-  final HomeState _value;
   // ignore: unused_field
-  final $Res Function(HomeState) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? googleMap = freezed,
-    Object? initialCameraPosition = freezed,
-    Object? markers = freezed,
-    Object? polylines = freezed,
-    Object? animationTempleId = freezed,
+    Object? googleMap = null,
+    Object? initialCameraPosition = null,
+    Object? markers = null,
+    Object? polylines = null,
+    Object? animationTempleId = null,
   }) {
     return _then(_value.copyWith(
-      googleMap: googleMap == freezed
+      googleMap: null == googleMap
           ? _value.googleMap
           : googleMap // ignore: cast_nullable_to_non_nullable
               as GoogleMapModel,
-      initialCameraPosition: initialCameraPosition == freezed
+      initialCameraPosition: null == initialCameraPosition
           ? _value.initialCameraPosition
           : initialCameraPosition // ignore: cast_nullable_to_non_nullable
               as CameraPosition,
-      markers: markers == freezed
+      markers: null == markers
           ? _value.markers
           : markers // ignore: cast_nullable_to_non_nullable
               as Set<Marker>,
-      polylines: polylines == freezed
+      polylines: null == polylines
           ? _value.polylines
           : polylines // ignore: cast_nullable_to_non_nullable
               as Set<Polyline>,
-      animationTempleId: animationTempleId == freezed
+      animationTempleId: null == animationTempleId
           ? _value.animationTempleId
           : animationTempleId // ignore: cast_nullable_to_non_nullable
               as int,
-    ));
+    ) as $Val);
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $GoogleMapModelCopyWith<$Res> get googleMap {
     return $GoogleMapModelCopyWith<$Res>(_value.googleMap, (value) {
-      return _then(_value.copyWith(googleMap: value));
+      return _then(_value.copyWith(googleMap: value) as $Val);
     });
   }
 }
@@ -96,6 +101,7 @@ abstract class _$$_HomeStateCopyWith<$Res> implements $HomeStateCopyWith<$Res> {
           _$_HomeState value, $Res Function(_$_HomeState) then) =
       __$$_HomeStateCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {GoogleMapModel googleMap,
       CameraPosition initialCameraPosition,
@@ -108,41 +114,40 @@ abstract class _$$_HomeStateCopyWith<$Res> implements $HomeStateCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_HomeStateCopyWithImpl<$Res> extends _$HomeStateCopyWithImpl<$Res>
+class __$$_HomeStateCopyWithImpl<$Res>
+    extends _$HomeStateCopyWithImpl<$Res, _$_HomeState>
     implements _$$_HomeStateCopyWith<$Res> {
   __$$_HomeStateCopyWithImpl(
       _$_HomeState _value, $Res Function(_$_HomeState) _then)
-      : super(_value, (v) => _then(v as _$_HomeState));
+      : super(_value, _then);
 
-  @override
-  _$_HomeState get _value => super._value as _$_HomeState;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? googleMap = freezed,
-    Object? initialCameraPosition = freezed,
-    Object? markers = freezed,
-    Object? polylines = freezed,
-    Object? animationTempleId = freezed,
+    Object? googleMap = null,
+    Object? initialCameraPosition = null,
+    Object? markers = null,
+    Object? polylines = null,
+    Object? animationTempleId = null,
   }) {
     return _then(_$_HomeState(
-      googleMap: googleMap == freezed
+      googleMap: null == googleMap
           ? _value.googleMap
           : googleMap // ignore: cast_nullable_to_non_nullable
               as GoogleMapModel,
-      initialCameraPosition: initialCameraPosition == freezed
+      initialCameraPosition: null == initialCameraPosition
           ? _value.initialCameraPosition
           : initialCameraPosition // ignore: cast_nullable_to_non_nullable
               as CameraPosition,
-      markers: markers == freezed
+      markers: null == markers
           ? _value._markers
           : markers // ignore: cast_nullable_to_non_nullable
               as Set<Marker>,
-      polylines: polylines == freezed
+      polylines: null == polylines
           ? _value._polylines
           : polylines // ignore: cast_nullable_to_non_nullable
               as Set<Polyline>,
-      animationTempleId: animationTempleId == freezed
+      animationTempleId: null == animationTempleId
           ? _value.animationTempleId
           : animationTempleId // ignore: cast_nullable_to_non_nullable
               as int,
@@ -197,27 +202,29 @@ class _$_HomeState extends _HomeState {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_HomeState &&
-            const DeepCollectionEquality().equals(other.googleMap, googleMap) &&
-            const DeepCollectionEquality()
-                .equals(other.initialCameraPosition, initialCameraPosition) &&
+            (identical(other.googleMap, googleMap) ||
+                other.googleMap == googleMap) &&
+            (identical(other.initialCameraPosition, initialCameraPosition) ||
+                other.initialCameraPosition == initialCameraPosition) &&
             const DeepCollectionEquality().equals(other._markers, _markers) &&
             const DeepCollectionEquality()
                 .equals(other._polylines, _polylines) &&
-            const DeepCollectionEquality()
-                .equals(other.animationTempleId, animationTempleId));
+            (identical(other.animationTempleId, animationTempleId) ||
+                other.animationTempleId == animationTempleId));
   }
 
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      const DeepCollectionEquality().hash(googleMap),
-      const DeepCollectionEquality().hash(initialCameraPosition),
+      googleMap,
+      initialCameraPosition,
       const DeepCollectionEquality().hash(_markers),
       const DeepCollectionEquality().hash(_polylines),
-      const DeepCollectionEquality().hash(animationTempleId));
+      animationTempleId);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_HomeStateCopyWith<_$_HomeState> get copyWith =>
       __$$_HomeStateCopyWithImpl<_$_HomeState>(this, _$identity);
 }

--- a/lib/ui/pages/profile/profile_presenter.dart
+++ b/lib/ui/pages/profile/profile_presenter.dart
@@ -49,10 +49,12 @@ final profileProvider =
 
 class ProfilePresenter extends StateNotifier<ProfileState> {
   ProfilePresenter(this._ref) : super(ProfileState(selectedTabIndex: 0)) {
-    _ref.read(pageTypeProvider.notifier).state = PageType.profile;
     _updateUserProfileImageInteractor = _ref.read(updateUserProfileImageUsecaseProvider);
     _userIconRepository = _ref.read(userIconRepositoryProvider);
     _analytics = _ref.read(analyticsProvider);
+    _ref.read(pageTypeProvider.notifier).addListener((state) {
+      state = PageType.profile;
+    });
   }
 
   final Ref _ref;

--- a/lib/ui/pages/profile/profile_presenter.dart
+++ b/lib/ui/pages/profile/profile_presenter.dart
@@ -13,7 +13,6 @@ import 'package:virtualpilgrimage/domain/user/user_repository.dart';
 import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
 import 'package:virtualpilgrimage/infrastructure/firebase/firebase_crashlytics_provider.dart';
 import 'package:virtualpilgrimage/logger.dart';
-import 'package:virtualpilgrimage/ui/components/bottom_navigation.dart';
 import 'package:virtualpilgrimage/ui/pages/profile/profile_state.codegen.dart';
 
 final profileUserProvider =
@@ -52,9 +51,6 @@ class ProfilePresenter extends StateNotifier<ProfileState> {
     _updateUserProfileImageInteractor = _ref.read(updateUserProfileImageUsecaseProvider);
     _userIconRepository = _ref.read(userIconRepositoryProvider);
     _analytics = _ref.read(analyticsProvider);
-    _ref.read(pageTypeProvider.notifier).addListener((state) {
-      state = PageType.profile;
-    });
   }
 
   final Ref _ref;

--- a/lib/ui/pages/profile/profile_presenter.dart
+++ b/lib/ui/pages/profile/profile_presenter.dart
@@ -113,6 +113,6 @@ class ProfilePresenter extends StateNotifier<ProfileState> {
     );
     // GoogleMap 上で表示する userIcon も更新してstateを更新
     final bitmap = await _userIconRepository.loadIconImage(updatedUser.userIconUrl);
-    _ref.read(userStateProvider.state).state = updatedUser.setUserIconBitmap(bitmap);
+    _ref.read(userStateProvider.notifier).state = updatedUser.setUserIconBitmap(bitmap);
   }
 }

--- a/lib/ui/pages/profile/profile_state.codegen.freezed.dart
+++ b/lib/ui/pages/profile/profile_state.codegen.freezed.dart
@@ -27,28 +27,32 @@ mixin _$ProfileState {
 abstract class $ProfileStateCopyWith<$Res> {
   factory $ProfileStateCopyWith(
           ProfileState value, $Res Function(ProfileState) then) =
-      _$ProfileStateCopyWithImpl<$Res>;
+      _$ProfileStateCopyWithImpl<$Res, ProfileState>;
+  @useResult
   $Res call({int selectedTabIndex});
 }
 
 /// @nodoc
-class _$ProfileStateCopyWithImpl<$Res> implements $ProfileStateCopyWith<$Res> {
+class _$ProfileStateCopyWithImpl<$Res, $Val extends ProfileState>
+    implements $ProfileStateCopyWith<$Res> {
   _$ProfileStateCopyWithImpl(this._value, this._then);
 
-  final ProfileState _value;
   // ignore: unused_field
-  final $Res Function(ProfileState) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? selectedTabIndex = freezed,
+    Object? selectedTabIndex = null,
   }) {
     return _then(_value.copyWith(
-      selectedTabIndex: selectedTabIndex == freezed
+      selectedTabIndex: null == selectedTabIndex
           ? _value.selectedTabIndex
           : selectedTabIndex // ignore: cast_nullable_to_non_nullable
               as int,
-    ));
+    ) as $Val);
   }
 }
 
@@ -59,26 +63,25 @@ abstract class _$$_ProfileStateCopyWith<$Res>
           _$_ProfileState value, $Res Function(_$_ProfileState) then) =
       __$$_ProfileStateCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call({int selectedTabIndex});
 }
 
 /// @nodoc
 class __$$_ProfileStateCopyWithImpl<$Res>
-    extends _$ProfileStateCopyWithImpl<$Res>
+    extends _$ProfileStateCopyWithImpl<$Res, _$_ProfileState>
     implements _$$_ProfileStateCopyWith<$Res> {
   __$$_ProfileStateCopyWithImpl(
       _$_ProfileState _value, $Res Function(_$_ProfileState) _then)
-      : super(_value, (v) => _then(v as _$_ProfileState));
+      : super(_value, _then);
 
-  @override
-  _$_ProfileState get _value => super._value as _$_ProfileState;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? selectedTabIndex = freezed,
+    Object? selectedTabIndex = null,
   }) {
     return _then(_$_ProfileState(
-      selectedTabIndex: selectedTabIndex == freezed
+      selectedTabIndex: null == selectedTabIndex
           ? _value.selectedTabIndex
           : selectedTabIndex // ignore: cast_nullable_to_non_nullable
               as int,
@@ -104,16 +107,16 @@ class _$_ProfileState extends _ProfileState {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_ProfileState &&
-            const DeepCollectionEquality()
-                .equals(other.selectedTabIndex, selectedTabIndex));
+            (identical(other.selectedTabIndex, selectedTabIndex) ||
+                other.selectedTabIndex == selectedTabIndex));
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType, const DeepCollectionEquality().hash(selectedTabIndex));
+  int get hashCode => Object.hash(runtimeType, selectedTabIndex);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_ProfileStateCopyWith<_$_ProfileState> get copyWith =>
       __$$_ProfileStateCopyWithImpl<_$_ProfileState>(this, _$identity);
 }

--- a/lib/ui/pages/registration/registration_presenter.dart
+++ b/lib/ui/pages/registration/registration_presenter.dart
@@ -163,7 +163,7 @@ class RegistrationPresenter extends StateNotifier<RegistrationState> {
   Future<void> onPressedLogout() async {
     await _ref.read(analyticsProvider).logEvent(eventName: AnalyticsEvent.logout);
     await _ref.read(signInUsecaseProvider).logout();
-    _ref.read(loginStateProvider.state).state = null;
+    _ref.read(loginStateProvider.notifier).state = null;
     _ref.read(routerProvider).go(RouterPath.signIn);
   }
 }

--- a/lib/ui/pages/registration/registration_presenter.dart
+++ b/lib/ui/pages/registration/registration_presenter.dart
@@ -12,6 +12,7 @@ import 'package:virtualpilgrimage/infrastructure/firebase/firebase_crashlytics_p
 import 'package:virtualpilgrimage/model/form_model.codegen.dart';
 import 'package:virtualpilgrimage/model/radio_button_model.codegen.dart';
 import 'package:virtualpilgrimage/router.dart';
+import 'package:virtualpilgrimage/ui/components/bottom_navigation.dart';
 import 'package:virtualpilgrimage/ui/pages/registration/registration_state.codegen.dart';
 import 'package:virtualpilgrimage/ui/style/color.dart';
 
@@ -133,6 +134,7 @@ class RegistrationPresenter extends StateNotifier<RegistrationState> {
       case RegistrationResultStatus.success:
         if (isRegistered) {
           // 登録済みの場合はloginStateが更新されないので、強制的にページ遷移させる
+          _ref.read(pageTypeProvider.notifier).state = PageType.home;
           _ref.read(routerProvider).go(RouterPath.home);
         } else {
           _loginStateNotifier.state = updatedUser.userStatus;

--- a/lib/ui/pages/registration/registration_state.codegen.freezed.dart
+++ b/lib/ui/pages/registration/registration_state.codegen.freezed.dart
@@ -29,7 +29,8 @@ mixin _$RegistrationState {
 abstract class $RegistrationStateCopyWith<$Res> {
   factory $RegistrationStateCopyWith(
           RegistrationState value, $Res Function(RegistrationState) then) =
-      _$RegistrationStateCopyWithImpl<$Res>;
+      _$RegistrationStateCopyWithImpl<$Res, RegistrationState>;
+  @useResult
   $Res call(
       {FormModel nickname,
       FormModel birthday,
@@ -41,54 +42,59 @@ abstract class $RegistrationStateCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$RegistrationStateCopyWithImpl<$Res>
+class _$RegistrationStateCopyWithImpl<$Res, $Val extends RegistrationState>
     implements $RegistrationStateCopyWith<$Res> {
   _$RegistrationStateCopyWithImpl(this._value, this._then);
 
-  final RegistrationState _value;
   // ignore: unused_field
-  final $Res Function(RegistrationState) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? nickname = freezed,
-    Object? birthday = freezed,
-    Object? gender = freezed,
+    Object? nickname = null,
+    Object? birthday = null,
+    Object? gender = null,
   }) {
     return _then(_value.copyWith(
-      nickname: nickname == freezed
+      nickname: null == nickname
           ? _value.nickname
           : nickname // ignore: cast_nullable_to_non_nullable
               as FormModel,
-      birthday: birthday == freezed
+      birthday: null == birthday
           ? _value.birthday
           : birthday // ignore: cast_nullable_to_non_nullable
               as FormModel,
-      gender: gender == freezed
+      gender: null == gender
           ? _value.gender
           : gender // ignore: cast_nullable_to_non_nullable
               as RadioButtonModel<Gender>,
-    ));
+    ) as $Val);
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $FormModelCopyWith<$Res> get nickname {
     return $FormModelCopyWith<$Res>(_value.nickname, (value) {
-      return _then(_value.copyWith(nickname: value));
+      return _then(_value.copyWith(nickname: value) as $Val);
     });
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $FormModelCopyWith<$Res> get birthday {
     return $FormModelCopyWith<$Res>(_value.birthday, (value) {
-      return _then(_value.copyWith(birthday: value));
+      return _then(_value.copyWith(birthday: value) as $Val);
     });
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $RadioButtonModelCopyWith<Gender, $Res> get gender {
     return $RadioButtonModelCopyWith<Gender, $Res>(_value.gender, (value) {
-      return _then(_value.copyWith(gender: value));
+      return _then(_value.copyWith(gender: value) as $Val);
     });
   }
 }
@@ -100,6 +106,7 @@ abstract class _$$_RegistrationStateCopyWith<$Res>
           $Res Function(_$_RegistrationState) then) =
       __$$_RegistrationStateCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {FormModel nickname,
       FormModel birthday,
@@ -115,31 +122,29 @@ abstract class _$$_RegistrationStateCopyWith<$Res>
 
 /// @nodoc
 class __$$_RegistrationStateCopyWithImpl<$Res>
-    extends _$RegistrationStateCopyWithImpl<$Res>
+    extends _$RegistrationStateCopyWithImpl<$Res, _$_RegistrationState>
     implements _$$_RegistrationStateCopyWith<$Res> {
   __$$_RegistrationStateCopyWithImpl(
       _$_RegistrationState _value, $Res Function(_$_RegistrationState) _then)
-      : super(_value, (v) => _then(v as _$_RegistrationState));
+      : super(_value, _then);
 
-  @override
-  _$_RegistrationState get _value => super._value as _$_RegistrationState;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? nickname = freezed,
-    Object? birthday = freezed,
-    Object? gender = freezed,
+    Object? nickname = null,
+    Object? birthday = null,
+    Object? gender = null,
   }) {
     return _then(_$_RegistrationState(
-      nickname: nickname == freezed
+      nickname: null == nickname
           ? _value.nickname
           : nickname // ignore: cast_nullable_to_non_nullable
               as FormModel,
-      birthday: birthday == freezed
+      birthday: null == birthday
           ? _value.birthday
           : birthday // ignore: cast_nullable_to_non_nullable
               as FormModel,
-      gender: gender == freezed
+      gender: null == gender
           ? _value.gender
           : gender // ignore: cast_nullable_to_non_nullable
               as RadioButtonModel<Gender>,
@@ -171,20 +176,19 @@ class _$_RegistrationState extends _RegistrationState {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_RegistrationState &&
-            const DeepCollectionEquality().equals(other.nickname, nickname) &&
-            const DeepCollectionEquality().equals(other.birthday, birthday) &&
-            const DeepCollectionEquality().equals(other.gender, gender));
+            (identical(other.nickname, nickname) ||
+                other.nickname == nickname) &&
+            (identical(other.birthday, birthday) ||
+                other.birthday == birthday) &&
+            (identical(other.gender, gender) || other.gender == gender));
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(nickname),
-      const DeepCollectionEquality().hash(birthday),
-      const DeepCollectionEquality().hash(gender));
+  int get hashCode => Object.hash(runtimeType, nickname, birthday, gender);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_RegistrationStateCopyWith<_$_RegistrationState> get copyWith =>
       __$$_RegistrationStateCopyWithImpl<_$_RegistrationState>(
           this, _$identity);

--- a/lib/ui/pages/sign_in/sign_in_presenter.dart
+++ b/lib/ui/pages/sign_in/sign_in_presenter.dart
@@ -26,8 +26,8 @@ class SignInPresenter extends StateNotifier<SignInState> {
           ),
         ) {
     _signInUsecase = _ref.read(signInUsecaseProvider);
-    _userState = _ref.watch(userStateProvider.state);
-    _loginState = _ref.watch(loginStateProvider.state);
+    _userState = _ref.watch(userStateProvider.notifier);
+    _loginState = _ref.watch(loginStateProvider.notifier);
     _analytics = _ref.read(analyticsProvider);
     _crashlytics = _ref.read(firebaseCrashlyticsProvider);
   }

--- a/lib/ui/pages/sign_in/sign_in_state.codegen.freezed.dart
+++ b/lib/ui/pages/sign_in/sign_in_state.codegen.freezed.dart
@@ -30,7 +30,8 @@ mixin _$SignInState {
 abstract class $SignInStateCopyWith<$Res> {
   factory $SignInStateCopyWith(
           SignInState value, $Res Function(SignInState) then) =
-      _$SignInStateCopyWithImpl<$Res>;
+      _$SignInStateCopyWithImpl<$Res, SignInState>;
+  @useResult
   $Res call(
       {SignInStateContext context,
       bool isLoading,
@@ -42,51 +43,56 @@ abstract class $SignInStateCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$SignInStateCopyWithImpl<$Res> implements $SignInStateCopyWith<$Res> {
+class _$SignInStateCopyWithImpl<$Res, $Val extends SignInState>
+    implements $SignInStateCopyWith<$Res> {
   _$SignInStateCopyWithImpl(this._value, this._then);
 
-  final SignInState _value;
   // ignore: unused_field
-  final $Res Function(SignInState) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? context = freezed,
-    Object? isLoading = freezed,
-    Object? emailOrNickname = freezed,
-    Object? password = freezed,
+    Object? context = null,
+    Object? isLoading = null,
+    Object? emailOrNickname = null,
+    Object? password = null,
   }) {
     return _then(_value.copyWith(
-      context: context == freezed
+      context: null == context
           ? _value.context
           : context // ignore: cast_nullable_to_non_nullable
               as SignInStateContext,
-      isLoading: isLoading == freezed
+      isLoading: null == isLoading
           ? _value.isLoading
           : isLoading // ignore: cast_nullable_to_non_nullable
               as bool,
-      emailOrNickname: emailOrNickname == freezed
+      emailOrNickname: null == emailOrNickname
           ? _value.emailOrNickname
           : emailOrNickname // ignore: cast_nullable_to_non_nullable
               as FormModel,
-      password: password == freezed
+      password: null == password
           ? _value.password
           : password // ignore: cast_nullable_to_non_nullable
               as FormModel,
-    ));
+    ) as $Val);
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $FormModelCopyWith<$Res> get emailOrNickname {
     return $FormModelCopyWith<$Res>(_value.emailOrNickname, (value) {
-      return _then(_value.copyWith(emailOrNickname: value));
+      return _then(_value.copyWith(emailOrNickname: value) as $Val);
     });
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $FormModelCopyWith<$Res> get password {
     return $FormModelCopyWith<$Res>(_value.password, (value) {
-      return _then(_value.copyWith(password: value));
+      return _then(_value.copyWith(password: value) as $Val);
     });
   }
 }
@@ -98,6 +104,7 @@ abstract class _$$_SignInStateCopyWith<$Res>
           _$_SignInState value, $Res Function(_$_SignInState) then) =
       __$$_SignInStateCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {SignInStateContext context,
       bool isLoading,
@@ -111,36 +118,35 @@ abstract class _$$_SignInStateCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_SignInStateCopyWithImpl<$Res> extends _$SignInStateCopyWithImpl<$Res>
+class __$$_SignInStateCopyWithImpl<$Res>
+    extends _$SignInStateCopyWithImpl<$Res, _$_SignInState>
     implements _$$_SignInStateCopyWith<$Res> {
   __$$_SignInStateCopyWithImpl(
       _$_SignInState _value, $Res Function(_$_SignInState) _then)
-      : super(_value, (v) => _then(v as _$_SignInState));
+      : super(_value, _then);
 
-  @override
-  _$_SignInState get _value => super._value as _$_SignInState;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? context = freezed,
-    Object? isLoading = freezed,
-    Object? emailOrNickname = freezed,
-    Object? password = freezed,
+    Object? context = null,
+    Object? isLoading = null,
+    Object? emailOrNickname = null,
+    Object? password = null,
   }) {
     return _then(_$_SignInState(
-      context: context == freezed
+      context: null == context
           ? _value.context
           : context // ignore: cast_nullable_to_non_nullable
               as SignInStateContext,
-      isLoading: isLoading == freezed
+      isLoading: null == isLoading
           ? _value.isLoading
           : isLoading // ignore: cast_nullable_to_non_nullable
               as bool,
-      emailOrNickname: emailOrNickname == freezed
+      emailOrNickname: null == emailOrNickname
           ? _value.emailOrNickname
           : emailOrNickname // ignore: cast_nullable_to_non_nullable
               as FormModel,
-      password: password == freezed
+      password: null == password
           ? _value.password
           : password // ignore: cast_nullable_to_non_nullable
               as FormModel,
@@ -179,23 +185,22 @@ class _$_SignInState extends _SignInState {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_SignInState &&
-            const DeepCollectionEquality().equals(other.context, context) &&
-            const DeepCollectionEquality().equals(other.isLoading, isLoading) &&
-            const DeepCollectionEquality()
-                .equals(other.emailOrNickname, emailOrNickname) &&
-            const DeepCollectionEquality().equals(other.password, password));
+            (identical(other.context, context) || other.context == context) &&
+            (identical(other.isLoading, isLoading) ||
+                other.isLoading == isLoading) &&
+            (identical(other.emailOrNickname, emailOrNickname) ||
+                other.emailOrNickname == emailOrNickname) &&
+            (identical(other.password, password) ||
+                other.password == password));
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(context),
-      const DeepCollectionEquality().hash(isLoading),
-      const DeepCollectionEquality().hash(emailOrNickname),
-      const DeepCollectionEquality().hash(password));
+  int get hashCode =>
+      Object.hash(runtimeType, context, isLoading, emailOrNickname, password);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_SignInStateCopyWith<_$_SignInState> get copyWith =>
       __$$_SignInStateCopyWithImpl<_$_SignInState>(this, _$identity);
 }

--- a/lib/ui/pages/temple/temple_page.dart
+++ b/lib/ui/pages/temple/temple_page.dart
@@ -4,6 +4,7 @@ import 'package:virtualpilgrimage/domain/temple/temple_info.codegen.dart';
 import 'package:virtualpilgrimage/domain/user/virtual_pilgrimage_user.codegen.dart';
 import 'package:virtualpilgrimage/infrastructure/temple/temple_repository_impl.dart';
 import 'package:virtualpilgrimage/ui/components/bottom_navigation.dart';
+import 'package:virtualpilgrimage/ui/components/molecules/my_drawer.dart';
 import 'package:virtualpilgrimage/ui/components/my_app_bar.dart';
 import 'package:virtualpilgrimage/ui/pages/temple/temple_detail_dialog.dart';
 import 'package:virtualpilgrimage/ui/style/font.dart';
@@ -16,11 +17,13 @@ class TemplePage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
+      key: MyDrawer.globalScaffoldKey,
       appBar: const MyAppBar(),
       body: SafeArea(
         child: _TemplePageBody(ref: ref),
       ),
       bottomNavigationBar: const BottomNavigation(),
+      endDrawer: const MyDrawer(),
     );
   }
 }
@@ -36,6 +39,9 @@ class _TemplePageBody extends StatelessWidget {
   Widget build(BuildContext context) {
     final temples = ref.watch(templeInfoCache);
     final user = ref.watch(userStateProvider);
+    ref.read(pageTypeProvider.notifier).addListener((state) {
+      state = PageType.profile;
+    });
 
     return ListView.builder(
       itemBuilder: (BuildContext context, int index) {

--- a/lib/ui/pages/temple/temple_page.dart
+++ b/lib/ui/pages/temple/temple_page.dart
@@ -39,9 +39,6 @@ class _TemplePageBody extends StatelessWidget {
   Widget build(BuildContext context) {
     final temples = ref.watch(templeInfoCache);
     final user = ref.watch(userStateProvider);
-    ref.read(pageTypeProvider.notifier).addListener((state) {
-      state = PageType.profile;
-    });
 
     return ListView.builder(
       itemBuilder: (BuildContext context, int index) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -289,12 +289,12 @@ packages:
     source: hosted
     version: "1.24.0"
   firebase_core_platform_interface:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: firebase_core_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.5.2"
+    version: "4.5.1"
   firebase_core_web:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,35 +7,42 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "46.0.0"
+    version: "50.0.0"
+  _flutterfire_internals:
+    dependency: transitive
+    description:
+      name: _flutterfire_internals
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "5.2.0"
   archive:
     dependency: transitive
     description:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.1"
+    version: "3.3.2"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -56,7 +63,7 @@ packages:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   build_daemon:
     dependency: transitive
     description:
@@ -70,21 +77,21 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.1.0"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.2"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.2.3"
+    version: "7.2.7"
   built_collection:
     dependency: transitive
     description:
@@ -98,21 +105,14 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.4.1"
+    version: "8.4.2"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -133,35 +133,35 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   cloud_firestore:
     dependency: "direct main"
     description:
       name: cloud_firestore
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.4.4"
+    version: "3.5.1"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.7.1"
+    version: "5.7.7"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.4"
+    version: "2.8.10"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "4.3.0"
   collection:
     dependency: transitive
     description:
@@ -175,7 +175,7 @@ packages:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.1"
   cross_file:
     dependency: transitive
     description:
@@ -203,56 +203,28 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.4"
   device_info_plus:
     dependency: transitive
     description:
       name: device_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.2"
-  device_info_plus_linux:
-    dependency: transitive
-    description:
-      name: device_info_plus_linux
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.0.0"
-  device_info_plus_macos:
-    dependency: transitive
-    description:
-      name: device_info_plus_macos
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.0.0"
+    version: "8.0.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
       name: device_info_plus_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
-  device_info_plus_web:
-    dependency: transitive
-    description:
-      name: device_info_plus_web
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.0.0"
-  device_info_plus_windows:
-    dependency: transitive
-    description:
-      name: device_info_plus_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "4.1.0"
+    version: "7.0.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
@@ -273,56 +245,56 @@ packages:
       name: firebase_analytics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.3.1"
+    version: "9.3.8"
   firebase_analytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_analytics_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.1"
+    version: "3.3.7"
   firebase_analytics_web:
     dependency: transitive
     description:
       name: firebase_analytics_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2+1"
+    version: "0.4.2+7"
   firebase_auth:
     dependency: "direct main"
     description:
       name: firebase_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.6.3"
+    version: "3.11.2"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.5.3"
+    version: "6.10.1"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.3"
+    version: "4.6.1"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.20.1"
+    version: "1.24.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.5.1"
+    version: "4.5.2"
   firebase_core_web:
     dependency: transitive
     description:
@@ -336,35 +308,35 @@ packages:
       name: firebase_crashlytics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.7"
+    version: "2.9.0"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_crashlytics_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.13"
+    version: "3.3.0"
   firebase_storage:
     dependency: "direct main"
     description:
       name: firebase_storage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "10.3.8"
+    version: "10.3.11"
   firebase_storage_platform_interface:
     dependency: transitive
     description:
       name: firebase_storage_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.16"
+    version: "4.1.19"
   firebase_storage_web:
     dependency: transitive
     description:
       name: firebase_storage_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.6"
+    version: "3.3.9"
   fixnum:
     dependency: transitive
     description:
@@ -377,15 +349,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_datetime_picker:
-    dependency: "direct main"
-    description:
-      path: "."
-      ref: master
-      resolved-ref: eb66486c47d50bf550950c196486121ffcea8885
-      url: "https://github.com/Realank/flutter_datetime_picker.git"
-    source: git
-    version: "1.5.1"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -413,7 +376,7 @@ packages:
       name: flutter_riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0-dev.9"
+    version: "2.1.1"
   flutter_signin_button:
     dependency: "direct main"
     description:
@@ -451,21 +414,21 @@ packages:
       name: freezed
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0+1"
+    version: "2.2.1"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "3.1.0"
   glob:
     dependency: transitive
     description:
@@ -479,35 +442,35 @@ packages:
       name: go_router
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.5.1"
+    version: "5.1.5"
   google_maps_flutter:
     dependency: "direct main"
     description:
       name: google_maps_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   google_maps_flutter_android:
     dependency: transitive
     description:
       name: google_maps_flutter_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.3"
   google_maps_flutter_ios:
     dependency: transitive
     description:
       name: google_maps_flutter_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.11"
+    version: "2.1.12"
   google_maps_flutter_platform_interface:
     dependency: transitive
     description:
       name: google_maps_flutter_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.4"
   google_polyline_algorithm:
     dependency: "direct main"
     description:
@@ -521,28 +484,28 @@ packages:
       name: google_sign_in
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.4.1"
+    version: "5.4.2"
   google_sign_in_android:
     dependency: transitive
     description:
       name: google_sign_in_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.1"
+    version: "6.1.1"
   google_sign_in_ios:
     dependency: transitive
     description:
       name: google_sign_in_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.4.0"
+    version: "5.5.0"
   google_sign_in_platform_interface:
     dependency: transitive
     description:
       name: google_sign_in_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   google_sign_in_web:
     dependency: transitive
     description:
@@ -556,14 +519,14 @@ packages:
       name: graphs
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   health:
     dependency: "direct main"
     description:
       name: health
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.1"
+    version: "4.3.0"
   http:
     dependency: "direct main"
     description:
@@ -584,21 +547,21 @@ packages:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "4.0.2"
   image:
     dependency: transitive
     description:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.2"
   image_picker:
     dependency: "direct main"
     description:
       name: image_picker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.5+3"
+    version: "0.8.6"
   image_picker_android:
     dependency: transitive
     description:
@@ -654,21 +617,21 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "4.7.0"
   json_serializable:
     dependency: "direct main"
     description:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.3.1"
+    version: "6.5.4"
   lints:
     dependency: transitive
     description:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   logger:
     dependency: "direct main"
     description:
@@ -682,7 +645,7 @@ packages:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.0"
   maps_toolkit:
     dependency: "direct main"
     description:
@@ -696,21 +659,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   mime:
     dependency: transitive
     description:
@@ -724,7 +687,7 @@ packages:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.3.0"
+    version: "5.3.2"
   package_config:
     dependency: transitive
     description:
@@ -738,7 +701,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   percent_indicator:
     dependency: "direct main"
     description:
@@ -766,35 +729,35 @@ packages:
       name: permission_handler_apple
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.0.4"
+    version: "9.0.7"
   permission_handler_platform_interface:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.7.0"
+    version: "3.9.0"
   permission_handler_windows:
     dependency: transitive
     description:
       name: permission_handler_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.2"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "5.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   pool:
     dependency: transitive
     description:
@@ -808,7 +771,7 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   pubspec_parse:
     dependency: transitive
     description:
@@ -829,21 +792,21 @@ packages:
       name: riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0-dev.9"
+    version: "2.1.1"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -855,21 +818,21 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.6"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -897,28 +860,28 @@ packages:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   timing:
     dependency: transitive
     description:
@@ -946,7 +909,7 @@ packages:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   web_socket_channel:
     dependency: transitive
     description:
@@ -960,7 +923,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.1.0"
   xml:
     dependency: transitive
     description:
@@ -976,5 +939,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.6 <3.0.0"
-  flutter: ">=3.0.0"
+  dart: ">=2.18.0 <3.0.0"
+  flutter: ">=3.3.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   # core以外のバージョンを指定しないことでcoreに依存したバージョンがインストールされる
   # 2022/11現在、coreの2系は安定していないらしいので、1系の最新を導入
   firebase_core: ^1.24.0
+  firebase_core_platform_interface: 4.5.1
   firebase_analytics:
   firebase_auth:
   cloud_firestore:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: virtualpilgrimage
-description: A new Flutter project.
+description: healthcare app to enjoy Shikoku Pilgrimage
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
@@ -33,54 +33,49 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
+  cupertino_icons: ^1.0.5
   # firebase
-  firebase_core: ^1.20.1
-  firebase_analytics: ^9.3.1
-  firebase_auth: ^3.6.3
-  cloud_firestore: ^3.4.4
-  firebase_crashlytics: ^2.8.7
+  # core以外のバージョンを指定しないことでcoreに依存したバージョンがインストールされる
+  # 2022/11現在、coreの2系は安定していないらしいので、1系の最新を導入
+  firebase_core: ^1.24.0
+  firebase_analytics:
+  firebase_auth:
+  cloud_firestore:
+  firebase_crashlytics:
+  firebase_storage:
+
   # utilities
-  flutter_riverpod: ^2.0.0-dev.9
-  go_router: ^4.5.1
+  flutter_riverpod: ^2.1.1
+  go_router: ^5.1.5
   flutter_signin_button: ^2.0.0
   google_sign_in: ^5.4.1
   logger: ^1.1.0
-  freezed_annotation: ^2.1.0
-  json_serializable: ^6.3.1
-  json_annotation: ^4.6.0
+  freezed_annotation: ^2.2.0
+  json_serializable: ^6.5.4
+  json_annotation: ^4.7.0
   intl: ^0.17.0
   http: ^0.13.5
-  image_picker: ^0.8.5+3
+  image_picker: ^0.8.6
+  maps_toolkit: ^2.0.1
+
   # ui
-  flutter_datetime_picker:
-    # pub.dev からダウンロードできるバージョンだと warn ログが出るので最新バージョンを利用
-    git:
-      url: https://github.com/Realank/flutter_datetime_picker.git
-      ref: master
-  google_maps_flutter: ^2.2.0
+  google_maps_flutter: ^2.2.1
   google_polyline_algorithm: ^3.1.0
   flutter_toggle_tab: ^1.2.0
   percent_indicator: ^4.2.2
+
   # health
-  health: ^4.1.1
+  health: ^4.3.0
   permission_handler: ^9.2.0 # Firebaseと同じSDKをターゲットにできるよう最新ではないバージョンを利用
-  firebase_storage: ^10.3.8
-  maps_toolkit: ^2.0.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  # The "flutter_lints" package below contains a set of recommended lints to
-  # encourage good coding practices. The lint set provided by the package is
-  # activated in the `analysis_options.yaml` file located at the root of your
-  # package. See that file for information about deactivating specific lint
-  # rules and activating additional ones.
-  flutter_lints: ^2.0.0
-  build_runner: ^2.2.0
-  freezed: ^2.1.0+1
-  mockito: ^5.3.0
+  flutter_lints: ^2.0.1
+  build_runner: ^2.3.2
+  freezed: ^2.2.1
+  mockito: ^5.3.2
 
   flutter_launcher_icons: ^0.10.0
 

--- a/test/helper/provider_container.dart
+++ b/test/helper/provider_container.dart
@@ -15,7 +15,7 @@ final defaultOverrides = <Override>[
   firebaseAuthProvider.overrideWithValue(MockFirebaseAuth()),
   firestoreProvider.overrideWithValue(MockFirebaseFirestore()),
   storageProvider.overrideWithValue(MockFirebaseStorage()),
-  firebaseAuthUserStateProvider.overrideWithValue(StateController(MockUser())),
+  firebaseAuthUserStateProvider.overrideWith((ref) => MockUser()),
   firebaseCrashlyticsProvider.overrideWithValue(MockFirebaseCrashlytics()),
   firebaseAnalyticsProvider.overrideWithValue(MockFirebaseAnalytics()),
   // google signIn

--- a/test/infrastructure/temple/temple_repository_impl_test.dart
+++ b/test/infrastructure/temple/temple_repository_impl_test.dart
@@ -74,7 +74,7 @@ void main() {
         });
         test('キャッシュからお寺の情報を取得できる', () async {
           // given
-          container.read(templeInfoCache.state).state = {11: defaultTempleInfo(11)};
+          container.read(templeInfoCache.notifier).state = {11: defaultTempleInfo(11)};
 
           // when
           final actual = await target.getTempleInfo(11);


### PR DESCRIPTION
@itomizu 
お疲れ様です。
Flutter ・Dart を最新バージョン更新しました。
また、ライブラリも可能な限り最新バージョンに近づけ、破壊的変更に対する対応を入れました。

詳細は https://medium.com/flutter/whats-new-in-flutter-3-3-893c7b9af1ff などにまとめられていますが、我々視点だと以下が大きな変更点になります。
- 各 Widget で Material Design 3 が有効化（すでに `useMaterial3` フラグを入れて利用中ですが）
- go_router が 5 系に
- riverpod の 2 系がリリース状態に

マージ後、flutter のアップデートと pub get が必要です