### PR TITLE
firebase で get を使うときにキャッシュを使わないよう修正

### DIFF
--- a/lib/infrastructure/user/user_repository_impl.dart
+++ b/lib/infrastructure/user/user_repository_impl.dart
@@ -25,7 +25,8 @@ class UserRepositoryImpl extends UserRepository {
                 VirtualPilgrimageUser.fromJson(snapshot.data()!),
             toFirestore: (VirtualPilgrimageUser user, _) => user.toJson(),
           );
-      final userSnapshot = await ref.get();
+      // よくデータが更新されるので、キャッシュを使わないようにsourceをserverだけにしている
+      final userSnapshot = await ref.get(const GetOptions(source: Source.server));
       final user = userSnapshot.data();
       if (userSnapshot.exists && user != null) {
         _logger.d(user);
@@ -78,7 +79,8 @@ class UserRepositoryImpl extends UserRepository {
               VirtualPilgrimageUser.fromJson(snapshot.data()!),
           toFirestore: (VirtualPilgrimageUser user, _) => user.toJson(),
         );
-    final snapshot = await ref.get();
+    // よくデータが更新されるので、キャッシュを使わないようにsourceをserverだけにしている
+    final snapshot = await ref.get(const GetOptions(source: Source.server));
     if (snapshot.size == 0) {
       return null;
     }

--- a/test/infrastructure/user/user_repository_impl_test.dart
+++ b/test/infrastructure/user/user_repository_impl_test.dart
@@ -1,5 +1,4 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:logger/logger.dart';
 import 'package:mockito/mockito.dart';
@@ -60,7 +59,7 @@ void main() {
       setUp(() {
         when(mockDocumentSnapshot.data()).thenReturn(expected);
         when(mockDocumentSnapshot.exists).thenReturn(true);
-        when(mockUserDocumentReference.get()).thenAnswer(
+        when(mockUserDocumentReference.get(const GetOptions(source: Source.server))).thenAnswer(
           (_) => Future.value(mockDocumentSnapshot),
         );
         when(
@@ -174,7 +173,7 @@ void main() {
         setUp(() {
           when(mockQuerySnapshot.docs).thenReturn(mockQueryDocumentSnapshots);
           when(mockQuerySnapshot.size).thenReturn(users.length);
-          when(mockQueryDomainUser.get()).thenAnswer(
+          when(mockQueryDomainUser.get(const GetOptions(source: Source.server))).thenAnswer(
             (_) => Future.value(mockQuerySnapshot),
           );
           when(


### PR DESCRIPTION
キャッシュを使うことでアプリケーションの速度が高速化しますが、取得した情報が最新版のものじゃないことでロジックに悪影響が出ているみたいなので、キャッシュを使わない設定を入れてみました。

軽微な修正なのでセルフマージして検証します