### PR TITLE
Health情報の取得に失敗したとき、不用意にDBのHealth情報を上書きしないように修正

### DIFF
--- a/lib/domain/user/health/health_by_period.codegen.dart
+++ b/lib/domain/user/health/health_by_period.codegen.dart
@@ -25,4 +25,8 @@ class HealthByPeriod with _$HealthByPeriod {
 
   factory HealthByPeriod.fromJson(Map<String, dynamic> json) =>
       _$HealthByPeriodFromJson(json);
+
+  bool validate() {
+    return steps > 0 && distance > 0 && burnedCalorie > 0;
+  }
 }

--- a/lib/domain/user/virtual_pilgrimage_user.codegen.dart
+++ b/lib/domain/user/virtual_pilgrimage_user.codegen.dart
@@ -186,7 +186,23 @@ class VirtualPilgrimageUser with _$VirtualPilgrimageUser {
   VirtualPilgrimageUser toRegistration() => copyWith(userStatus: UserStatus.created);
 
   /// ヘルスケア情報を更新
-  VirtualPilgrimageUser updateHealth(HealthInfo health) => copyWith(health: health);
+  VirtualPilgrimageUser updateHealth(HealthInfo health) {
+    final nowHealth = this.health;
+    if (nowHealth == null) {
+      return copyWith(health: health);
+    }
+    // うまく取得できなかったデータは除外して更新する
+    final updatedHealth = HealthInfo(
+      today: health.today.validate() ? health.today : nowHealth.today,
+      yesterday: health.yesterday.validate() ? health.yesterday : nowHealth.yesterday,
+      week: health.week.validate() ? health.week : nowHealth.week,
+      month: health.month.validate() ? health.month : nowHealth.month,
+      updatedAt: updatedAt,
+      totalSteps: health.totalSteps > 0 ? health.totalSteps : nowHealth.totalSteps,
+      totalDistance: health.totalDistance > 0 ? health.totalDistance : nowHealth.totalDistance,
+    );
+    return copyWith(health: updatedHealth);
+  }
 
   /// お遍路の進捗を更新
   VirtualPilgrimageUser updatePilgrimageProgress(

--- a/lib/domain/user/virtual_pilgrimage_user.codegen.dart
+++ b/lib/domain/user/virtual_pilgrimage_user.codegen.dart
@@ -197,7 +197,7 @@ class VirtualPilgrimageUser with _$VirtualPilgrimageUser {
       yesterday: health.yesterday.validate() ? health.yesterday : nowHealth.yesterday,
       week: health.week.validate() ? health.week : nowHealth.week,
       month: health.month.validate() ? health.month : nowHealth.month,
-      updatedAt: updatedAt,
+      updatedAt: health.updatedAt,
       totalSteps: health.totalSteps > 0 ? health.totalSteps : nowHealth.totalSteps,
       totalDistance: health.totalDistance > 0 ? health.totalDistance : nowHealth.totalDistance,
     );

--- a/test/application/user/health/update_health_interactor_test.dart
+++ b/test/application/user/health/update_health_interactor_test.dart
@@ -39,16 +39,27 @@ void main() {
 
   group('UpdateHealthInteractor', () {
     final user = defaultUser();
+    CustomizableDateTime.customTime = DateTime.now();
     final health = HealthInfo(
       today: defaultHealthByPeriod(steps: 10, distance: 10, burnedCalorie: 10),
       yesterday: defaultHealthByPeriod(steps: 100, distance: 100, burnedCalorie: 100),
-      week: defaultHealthByPeriod(steps: 1000, distance: 1000, burnedCalorie: 1000),
+      week: defaultHealthByPeriod(steps: 0, distance: 1000, burnedCalorie: 1000),
       month: defaultHealthByPeriod(steps: 1000, distance: 10000, burnedCalorie: 10000),
-      totalSteps: 0,
+      totalSteps: 1000,
       totalDistance: 0,
       updatedAt: CustomizableDateTime.current,
     );
-    final updatedUser = user.copyWith(health: health);
+    final updatedUser = user.copyWith(
+      health: HealthInfo(
+        today: defaultHealthByPeriod(steps: 10, distance: 10, burnedCalorie: 10),
+        yesterday: defaultHealthByPeriod(steps: 100, distance: 100, burnedCalorie: 100),
+        week: defaultHealthByPeriod(),
+        month: defaultHealthByPeriod(steps: 1000, distance: 10000, burnedCalorie: 10000),
+        totalSteps: 1000,
+        totalDistance: 100,
+        updatedAt: CustomizableDateTime.current,
+      ),
+    );
 
     setUp(() {
       CustomizableDateTime.customTime = DateTime.now();
@@ -180,14 +191,14 @@ VirtualPilgrimageUser defaultUser() {
       yesterday: defaultHealthByPeriod(),
       week: defaultHealthByPeriod(),
       month: defaultHealthByPeriod(),
-      totalSteps: 0,
-      totalDistance: 0,
+      totalSteps: 100,
+      totalDistance: 100,
       updatedAt: CustomizableDateTime.current,
     ),
     pilgrimage: PilgrimageInfo(id: 'dummyId', updatedAt: CustomizableDateTime.current),
   );
 }
 
-HealthByPeriod defaultHealthByPeriod({int steps = 0, int distance = 0, int burnedCalorie = 0}) {
+HealthByPeriod defaultHealthByPeriod({int steps = 10, int distance = 10, int burnedCalorie = 10}) {
   return HealthByPeriod(steps: steps, distance: distance, burnedCalorie: burnedCalorie);
 }


### PR DESCRIPTION
（開発時だけかもしれないが）health パッケージを使ったHealth情報の取得において、歩数と移動距離が正常に取れない場合がある。

不用意にDBのHealth情報を上書きしてしまうとランキングに影響するので、事前にバリデーションするロジックを追加