### PR TITLE
過去の移動経路を描画するよう修正

### DIFF
--- a/lib/application/pilgrimage/update_pilgrimage_progress_interactor.dart
+++ b/lib/application/pilgrimage/update_pilgrimage_progress_interactor.dart
@@ -47,6 +47,8 @@ class UpdatePilgrimageProgressInteractor extends UpdatePilgrimageProgressUsecase
     final List<int> reachedPilgrimageIdList = [];
     try {
       final updatedProgressUser = await _calcPilgrimageProgress(user, now, reachedPilgrimageIdList);
+
+      // 現在経路の緯度経度を取得
       final nextTargetTempleInfo =
           await _templeRepository.getTempleInfo(updatedProgressUser.pilgrimage.nowPilgrimageId);
       final latlngs = nextTargetTempleInfo.decodeGeoPoint();

--- a/lib/application/pilgrimage/update_pilgrimage_progress_result.codegen.freezed.dart
+++ b/lib/application/pilgrimage/update_pilgrimage_progress_result.codegen.freezed.dart
@@ -22,8 +22,6 @@ mixin _$UpdatePilgrimageProgressResult {
   List<int> get reachedPilgrimageIdList =>
       throw _privateConstructorUsedError; // 現在、仮想的に移動している経路の緯度・経路のリスト
   List<LatLng> get virtualPolylineLatLngs =>
-      throw _privateConstructorUsedError; // 過去に仮想的に移動した経路の緯度・経度のリスト
-  List<LatLng> get pastPolylineLatLngs =>
       throw _privateConstructorUsedError; // 現在の仮想的なユーザの緯度・軽度
   LatLng? get virtualPosition =>
       throw _privateConstructorUsedError; // ロジックによって更新されたときのユーザの情報
@@ -48,7 +46,6 @@ abstract class $UpdatePilgrimageProgressResultCopyWith<$Res> {
       {UpdatePilgrimageProgressResultStatus status,
       List<int> reachedPilgrimageIdList,
       List<LatLng> virtualPolylineLatLngs,
-      List<LatLng> pastPolylineLatLngs,
       LatLng? virtualPosition,
       VirtualPilgrimageUser? updatedUser,
       Exception? error});
@@ -73,7 +70,6 @@ class _$UpdatePilgrimageProgressResultCopyWithImpl<$Res,
     Object? status = null,
     Object? reachedPilgrimageIdList = null,
     Object? virtualPolylineLatLngs = null,
-    Object? pastPolylineLatLngs = null,
     Object? virtualPosition = freezed,
     Object? updatedUser = freezed,
     Object? error = freezed,
@@ -90,10 +86,6 @@ class _$UpdatePilgrimageProgressResultCopyWithImpl<$Res,
       virtualPolylineLatLngs: null == virtualPolylineLatLngs
           ? _value.virtualPolylineLatLngs
           : virtualPolylineLatLngs // ignore: cast_nullable_to_non_nullable
-              as List<LatLng>,
-      pastPolylineLatLngs: null == pastPolylineLatLngs
-          ? _value.pastPolylineLatLngs
-          : pastPolylineLatLngs // ignore: cast_nullable_to_non_nullable
               as List<LatLng>,
       virtualPosition: freezed == virtualPosition
           ? _value.virtualPosition
@@ -136,7 +128,6 @@ abstract class _$$_UpdatePilgrimageProgressResultCopyWith<$Res>
       {UpdatePilgrimageProgressResultStatus status,
       List<int> reachedPilgrimageIdList,
       List<LatLng> virtualPolylineLatLngs,
-      List<LatLng> pastPolylineLatLngs,
       LatLng? virtualPosition,
       VirtualPilgrimageUser? updatedUser,
       Exception? error});
@@ -161,7 +152,6 @@ class __$$_UpdatePilgrimageProgressResultCopyWithImpl<$Res>
     Object? status = null,
     Object? reachedPilgrimageIdList = null,
     Object? virtualPolylineLatLngs = null,
-    Object? pastPolylineLatLngs = null,
     Object? virtualPosition = freezed,
     Object? updatedUser = freezed,
     Object? error = freezed,
@@ -178,10 +168,6 @@ class __$$_UpdatePilgrimageProgressResultCopyWithImpl<$Res>
       virtualPolylineLatLngs: null == virtualPolylineLatLngs
           ? _value._virtualPolylineLatLngs
           : virtualPolylineLatLngs // ignore: cast_nullable_to_non_nullable
-              as List<LatLng>,
-      pastPolylineLatLngs: null == pastPolylineLatLngs
-          ? _value._pastPolylineLatLngs
-          : pastPolylineLatLngs // ignore: cast_nullable_to_non_nullable
               as List<LatLng>,
       virtualPosition: freezed == virtualPosition
           ? _value.virtualPosition
@@ -207,13 +193,11 @@ class _$_UpdatePilgrimageProgressResult
       {required this.status,
       required final List<int> reachedPilgrimageIdList,
       final List<LatLng> virtualPolylineLatLngs = const [],
-      final List<LatLng> pastPolylineLatLngs = const [],
       this.virtualPosition,
       this.updatedUser,
       this.error})
       : _reachedPilgrimageIdList = reachedPilgrimageIdList,
         _virtualPolylineLatLngs = virtualPolylineLatLngs,
-        _pastPolylineLatLngs = pastPolylineLatLngs,
         super._();
 
 // お遍路の進捗更新結果の状態
@@ -238,16 +222,6 @@ class _$_UpdatePilgrimageProgressResult
     return EqualUnmodifiableListView(_virtualPolylineLatLngs);
   }
 
-// 過去に仮想的に移動した経路の緯度・経度のリスト
-  final List<LatLng> _pastPolylineLatLngs;
-// 過去に仮想的に移動した経路の緯度・経度のリスト
-  @override
-  @JsonKey()
-  List<LatLng> get pastPolylineLatLngs {
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_pastPolylineLatLngs);
-  }
-
 // 現在の仮想的なユーザの緯度・軽度
   @override
   final LatLng? virtualPosition;
@@ -260,7 +234,7 @@ class _$_UpdatePilgrimageProgressResult
 
   @override
   String toString() {
-    return 'UpdatePilgrimageProgressResult(status: $status, reachedPilgrimageIdList: $reachedPilgrimageIdList, virtualPolylineLatLngs: $virtualPolylineLatLngs, pastPolylineLatLngs: $pastPolylineLatLngs, virtualPosition: $virtualPosition, updatedUser: $updatedUser, error: $error)';
+    return 'UpdatePilgrimageProgressResult(status: $status, reachedPilgrimageIdList: $reachedPilgrimageIdList, virtualPolylineLatLngs: $virtualPolylineLatLngs, virtualPosition: $virtualPosition, updatedUser: $updatedUser, error: $error)';
   }
 
   @override
@@ -273,8 +247,6 @@ class _$_UpdatePilgrimageProgressResult
                 other._reachedPilgrimageIdList, _reachedPilgrimageIdList) &&
             const DeepCollectionEquality().equals(
                 other._virtualPolylineLatLngs, _virtualPolylineLatLngs) &&
-            const DeepCollectionEquality()
-                .equals(other._pastPolylineLatLngs, _pastPolylineLatLngs) &&
             (identical(other.virtualPosition, virtualPosition) ||
                 other.virtualPosition == virtualPosition) &&
             (identical(other.updatedUser, updatedUser) ||
@@ -288,7 +260,6 @@ class _$_UpdatePilgrimageProgressResult
       status,
       const DeepCollectionEquality().hash(_reachedPilgrimageIdList),
       const DeepCollectionEquality().hash(_virtualPolylineLatLngs),
-      const DeepCollectionEquality().hash(_pastPolylineLatLngs),
       virtualPosition,
       updatedUser,
       error);
@@ -307,7 +278,6 @@ abstract class _UpdatePilgrimageProgressResult
       {required final UpdatePilgrimageProgressResultStatus status,
       required final List<int> reachedPilgrimageIdList,
       final List<LatLng> virtualPolylineLatLngs,
-      final List<LatLng> pastPolylineLatLngs,
       final LatLng? virtualPosition,
       final VirtualPilgrimageUser? updatedUser,
       final Exception? error}) = _$_UpdatePilgrimageProgressResult;
@@ -319,8 +289,6 @@ abstract class _UpdatePilgrimageProgressResult
   List<int> get reachedPilgrimageIdList;
   @override // 現在、仮想的に移動している経路の緯度・経路のリスト
   List<LatLng> get virtualPolylineLatLngs;
-  @override // 過去に仮想的に移動した経路の緯度・経度のリスト
-  List<LatLng> get pastPolylineLatLngs;
   @override // 現在の仮想的なユーザの緯度・軽度
   LatLng? get virtualPosition;
   @override // ロジックによって更新されたときのユーザの情報

--- a/lib/application/pilgrimage/update_pilgrimage_progress_result.codegen.freezed.dart
+++ b/lib/application/pilgrimage/update_pilgrimage_progress_result.codegen.freezed.dart
@@ -22,6 +22,8 @@ mixin _$UpdatePilgrimageProgressResult {
   List<int> get reachedPilgrimageIdList =>
       throw _privateConstructorUsedError; // 現在、仮想的に移動している経路の緯度・経路のリスト
   List<LatLng> get virtualPolylineLatLngs =>
+      throw _privateConstructorUsedError; // 過去に仮想的に移動した経路の緯度・経度のリスト
+  List<LatLng> get pastPolylineLatLngs =>
       throw _privateConstructorUsedError; // 現在の仮想的なユーザの緯度・軽度
   LatLng? get virtualPosition =>
       throw _privateConstructorUsedError; // ロジックによって更新されたときのユーザの情報
@@ -46,6 +48,7 @@ abstract class $UpdatePilgrimageProgressResultCopyWith<$Res> {
       {UpdatePilgrimageProgressResultStatus status,
       List<int> reachedPilgrimageIdList,
       List<LatLng> virtualPolylineLatLngs,
+      List<LatLng> pastPolylineLatLngs,
       LatLng? virtualPosition,
       VirtualPilgrimageUser? updatedUser,
       Exception? error});
@@ -70,6 +73,7 @@ class _$UpdatePilgrimageProgressResultCopyWithImpl<$Res,
     Object? status = null,
     Object? reachedPilgrimageIdList = null,
     Object? virtualPolylineLatLngs = null,
+    Object? pastPolylineLatLngs = null,
     Object? virtualPosition = freezed,
     Object? updatedUser = freezed,
     Object? error = freezed,
@@ -86,6 +90,10 @@ class _$UpdatePilgrimageProgressResultCopyWithImpl<$Res,
       virtualPolylineLatLngs: null == virtualPolylineLatLngs
           ? _value.virtualPolylineLatLngs
           : virtualPolylineLatLngs // ignore: cast_nullable_to_non_nullable
+              as List<LatLng>,
+      pastPolylineLatLngs: null == pastPolylineLatLngs
+          ? _value.pastPolylineLatLngs
+          : pastPolylineLatLngs // ignore: cast_nullable_to_non_nullable
               as List<LatLng>,
       virtualPosition: freezed == virtualPosition
           ? _value.virtualPosition
@@ -128,6 +136,7 @@ abstract class _$$_UpdatePilgrimageProgressResultCopyWith<$Res>
       {UpdatePilgrimageProgressResultStatus status,
       List<int> reachedPilgrimageIdList,
       List<LatLng> virtualPolylineLatLngs,
+      List<LatLng> pastPolylineLatLngs,
       LatLng? virtualPosition,
       VirtualPilgrimageUser? updatedUser,
       Exception? error});
@@ -152,6 +161,7 @@ class __$$_UpdatePilgrimageProgressResultCopyWithImpl<$Res>
     Object? status = null,
     Object? reachedPilgrimageIdList = null,
     Object? virtualPolylineLatLngs = null,
+    Object? pastPolylineLatLngs = null,
     Object? virtualPosition = freezed,
     Object? updatedUser = freezed,
     Object? error = freezed,
@@ -168,6 +178,10 @@ class __$$_UpdatePilgrimageProgressResultCopyWithImpl<$Res>
       virtualPolylineLatLngs: null == virtualPolylineLatLngs
           ? _value._virtualPolylineLatLngs
           : virtualPolylineLatLngs // ignore: cast_nullable_to_non_nullable
+              as List<LatLng>,
+      pastPolylineLatLngs: null == pastPolylineLatLngs
+          ? _value._pastPolylineLatLngs
+          : pastPolylineLatLngs // ignore: cast_nullable_to_non_nullable
               as List<LatLng>,
       virtualPosition: freezed == virtualPosition
           ? _value.virtualPosition
@@ -193,11 +207,13 @@ class _$_UpdatePilgrimageProgressResult
       {required this.status,
       required final List<int> reachedPilgrimageIdList,
       final List<LatLng> virtualPolylineLatLngs = const [],
+      final List<LatLng> pastPolylineLatLngs = const [],
       this.virtualPosition,
       this.updatedUser,
       this.error})
       : _reachedPilgrimageIdList = reachedPilgrimageIdList,
         _virtualPolylineLatLngs = virtualPolylineLatLngs,
+        _pastPolylineLatLngs = pastPolylineLatLngs,
         super._();
 
 // お遍路の進捗更新結果の状態
@@ -222,6 +238,16 @@ class _$_UpdatePilgrimageProgressResult
     return EqualUnmodifiableListView(_virtualPolylineLatLngs);
   }
 
+// 過去に仮想的に移動した経路の緯度・経度のリスト
+  final List<LatLng> _pastPolylineLatLngs;
+// 過去に仮想的に移動した経路の緯度・経度のリスト
+  @override
+  @JsonKey()
+  List<LatLng> get pastPolylineLatLngs {
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_pastPolylineLatLngs);
+  }
+
 // 現在の仮想的なユーザの緯度・軽度
   @override
   final LatLng? virtualPosition;
@@ -234,7 +260,7 @@ class _$_UpdatePilgrimageProgressResult
 
   @override
   String toString() {
-    return 'UpdatePilgrimageProgressResult(status: $status, reachedPilgrimageIdList: $reachedPilgrimageIdList, virtualPolylineLatLngs: $virtualPolylineLatLngs, virtualPosition: $virtualPosition, updatedUser: $updatedUser, error: $error)';
+    return 'UpdatePilgrimageProgressResult(status: $status, reachedPilgrimageIdList: $reachedPilgrimageIdList, virtualPolylineLatLngs: $virtualPolylineLatLngs, pastPolylineLatLngs: $pastPolylineLatLngs, virtualPosition: $virtualPosition, updatedUser: $updatedUser, error: $error)';
   }
 
   @override
@@ -247,6 +273,8 @@ class _$_UpdatePilgrimageProgressResult
                 other._reachedPilgrimageIdList, _reachedPilgrimageIdList) &&
             const DeepCollectionEquality().equals(
                 other._virtualPolylineLatLngs, _virtualPolylineLatLngs) &&
+            const DeepCollectionEquality()
+                .equals(other._pastPolylineLatLngs, _pastPolylineLatLngs) &&
             (identical(other.virtualPosition, virtualPosition) ||
                 other.virtualPosition == virtualPosition) &&
             (identical(other.updatedUser, updatedUser) ||
@@ -260,6 +288,7 @@ class _$_UpdatePilgrimageProgressResult
       status,
       const DeepCollectionEquality().hash(_reachedPilgrimageIdList),
       const DeepCollectionEquality().hash(_virtualPolylineLatLngs),
+      const DeepCollectionEquality().hash(_pastPolylineLatLngs),
       virtualPosition,
       updatedUser,
       error);
@@ -278,6 +307,7 @@ abstract class _UpdatePilgrimageProgressResult
       {required final UpdatePilgrimageProgressResultStatus status,
       required final List<int> reachedPilgrimageIdList,
       final List<LatLng> virtualPolylineLatLngs,
+      final List<LatLng> pastPolylineLatLngs,
       final LatLng? virtualPosition,
       final VirtualPilgrimageUser? updatedUser,
       final Exception? error}) = _$_UpdatePilgrimageProgressResult;
@@ -289,6 +319,8 @@ abstract class _UpdatePilgrimageProgressResult
   List<int> get reachedPilgrimageIdList;
   @override // 現在、仮想的に移動している経路の緯度・経路のリスト
   List<LatLng> get virtualPolylineLatLngs;
+  @override // 過去に仮想的に移動した経路の緯度・経度のリスト
+  List<LatLng> get pastPolylineLatLngs;
   @override // 現在の仮想的なユーザの緯度・軽度
   LatLng? get virtualPosition;
   @override // ロジックによって更新されたときのユーザの情報

--- a/lib/infrastructure/pilgrimage/temple_repository_impl.dart
+++ b/lib/infrastructure/pilgrimage/temple_repository_impl.dart
@@ -35,7 +35,7 @@ class TempleRepositoryImpl extends TempleRepository {
             toFirestore: (TempleInfo templeInfo, _) => templeInfo.toJson(),
           );
 
-      final templeSnapshot = await ref.get(const GetOptions(source: Source.server));
+      final templeSnapshot = await ref.get(const GetOptions(source: Source.serverAndCache));
       final data = templeSnapshot.data();
       if (templeSnapshot.exists && data != null) {
         return data;
@@ -65,7 +65,7 @@ class TempleRepositoryImpl extends TempleRepository {
     }
     try {
       // firebase からすベてのお寺情報を取得
-      final snapshot = await _firestore.collection(FirestoreCollectionPath.temples).get(const GetOptions(source: Source.server));
+      final snapshot = await _firestore.collection(FirestoreCollectionPath.temples).get(const GetOptions(source: Source.serverAndCache));
       final Map<int, TempleInfo> templeInfoMap = {};
       // domain entity に convert して id ごとに情報を詰める
       for (final doc in snapshot.docs) {
@@ -74,7 +74,7 @@ class TempleRepositoryImpl extends TempleRepository {
               fromFirestore: (snapshot, _) => TempleInfo.fromJson(snapshot.data()!),
               toFirestore: (TempleInfo templeInfo, _) => templeInfo.toJson(),
             )
-            .get(const GetOptions(source: Source.server));
+            .get(const GetOptions(source: Source.serverAndCache));
         final data = templeInfoSnapshot.data();
         if (templeInfoSnapshot.exists && data != null) {
           templeInfoMap.addAll({data.id: data});

--- a/test/infrastructure/pilgrimage/temple_repository_impl_test.dart
+++ b/test/infrastructure/pilgrimage/temple_repository_impl_test.dart
@@ -52,7 +52,7 @@ void main() {
           toFirestore: anyNamed('toFirestore'),
         ),
       ).thenReturn(mockTempleInfoDocumentReference);
-      when(mockTempleInfoDocumentReference.get(const GetOptions(source: Source.server))).thenAnswer(
+      when(mockTempleInfoDocumentReference.get(const GetOptions(source: Source.serverAndCache))).thenAnswer(
         (_) => Future.value(mockDocumentSnapshot),
       );
     });
@@ -89,7 +89,7 @@ void main() {
       final QuerySnapshot<Map<String, dynamic>> querySnapshot = MockQuerySnapshot();
       test('正常系', () async {
         // given
-        when(mockCollectionReference.get(const GetOptions(source: Source.server))).thenAnswer((_) => Future.value(querySnapshot));
+        when(mockCollectionReference.get(const GetOptions(source: Source.serverAndCache))).thenAnswer((_) => Future.value(querySnapshot));
         when(querySnapshot.docs).thenReturn([snapshot1, snapshot2]);
         when(mockDocumentSnapshot.exists).thenReturn(true);
         when(mockDocumentSnapshot.data()).thenReturn(defaultTempleInfo());
@@ -101,7 +101,7 @@ void main() {
         expect(container.read(templeInfoCache), {1: defaultTempleInfo()});
         verify(mockFirebaseFirestore.collection('temples')).called(1);
         verify(querySnapshot.docs).called(1);
-        verify(mockTempleInfoDocumentReference.get(const GetOptions(source: Source.server))).called(2);
+        verify(mockTempleInfoDocumentReference.get(const GetOptions(source: Source.serverAndCache))).called(2);
         verify(mockDocumentSnapshot.exists).called(2);
         verify(mockDocumentSnapshot.data()).called(2);
       });


### PR DESCRIPTION
表題の通りです。
要望があったため対応しました。

愚直に実装すると Firebase への問い合わせ回数が多くなったり、マップへの描画が遅くなって UX を損なうので、以下のように対応しました。
- 1度目のカメラポジションが変わる描画（経路情報の可視化）では過去経路は描画しない（この時点ではお寺情報のキャッシュが取れていないので）
- 2度目の経路情報の可視化時にお寺情報のキャッシュの取得を待ってから、過去経路の描画も含めた経路情報をセット