### PR TITLE
ランキングロジックの改善

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -46,5 +46,13 @@ service cloud.firestore {
         match /deleted_users/{userId} {
             allow create: if isUserAuthenticated(userId);
         }
+
+        match /rankings {
+            allow list: if true;
+        }
+
+        match /rankings/{document=**} {
+            allow list: if true;
+        }
     }
 }

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -1,6 +1,7 @@
 import { initializeApp } from "firebase-admin/app";
 import { config } from "firebase-functions";
 
+process.env.TZ = "Asia/Tokyo";
 initializeApp(config().firebase);
 
 export * from "./handlers";

--- a/lib/application/auth/auth_repository.dart
+++ b/lib/application/auth/auth_repository.dart
@@ -6,7 +6,12 @@ import 'package:virtualpilgrimage/infrastructure/auth/google_auth_repository.dar
 import 'package:virtualpilgrimage/infrastructure/firebase/firebase_auth_provider.dart';
 
 final googleSignInProvider = Provider(
-  (_) => GoogleSignIn(),
+  (_) => GoogleSignIn(
+    scopes: [
+      'email',
+    ],
+    hostedDomain: '',
+  ),
 );
 
 final emailAndPasswordAuthRepositoryProvider = Provider<AuthRepository>(

--- a/lib/ui/pages/home/home_presenter.dart
+++ b/lib/ui/pages/home/home_presenter.dart
@@ -168,7 +168,7 @@ class HomePresenter extends StateNotifier<HomeState> {
 
     Set<Marker> markers = state.markers;
     final virtualPosition = logicResult.virtualPosition;
-    if (virtualPosition != null) {
+    if (!updatePastPolylines && virtualPosition != null) {
       markers = {
         ...state.markers,
         Marker(

--- a/lib/ui/pages/ranking/ranking_page.dart
+++ b/lib/ui/pages/ranking/ranking_page.dart
@@ -105,7 +105,7 @@ class _RankingPageBody extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.all(8),
           child: Text(
-            '最終更新日: ${notifier.convertUpdatedTimeToDisplayFormat(ranking.value, RankingPeriod.values[periodTabController.index])} (毎日4時頃更新予定)',
+            '最終更新日: ${notifier.convertUpdatedTimeToDisplayFormat(ranking.value, RankingPeriod.values[periodTabController.index])}',
             style: const TextStyle(fontWeight: FontWeight.bold),
           ),
         ),

--- a/lib/ui/pages/ranking/ranking_presenter.dart
+++ b/lib/ui/pages/ranking/ranking_presenter.dart
@@ -33,7 +33,7 @@ class RankingPresenter extends StateNotifier<RankingState> {
 
   List<String> get periodTabLabels => _periodTabLabels;
 
-  final dateFormat = DateFormat('yyyy/MM/dd');
+  final dateFormat = DateFormat('yyyy/MM/dd hh時');
 
   /// 表示するランキング情報を選択する
   RankingUsers selectRanking(Ranking ranking, RankingKind kind, RankingPeriod period) {

--- a/test/ui/pages/ranking/ranking_page_test.dart
+++ b/test/ui/pages/ranking/ranking_page_test.dart
@@ -64,7 +64,7 @@ void main() {
       expect(find.text('dummyName3'), findsOneWidget);
       expect(find.text('5000 歩'), findsOneWidget);
       // デフォルトで表示されている情報
-      expect(find.text('最終更新日: 2022/12/31 (毎日4時頃更新予定)'), findsOneWidget);
+      expect(find.textContaining('最終更新日: 2022/12/31'), findsOneWidget);
       for (final kind in ['歩数', '距離']) {
         expect(find.text(kind), findsOneWidget);
       }


### PR DESCRIPTION
@kmsz46 

以下のように改善しました。
- 9:00 以降であれば昨日の、9:00 以前であれば今日の歩数を日次のランキングに使う
- 1時間ごとに集計（頻度はもう少し低くてもいいかもしれない）
- 昨日、1週間以内に、1ヶ月以内に更新したユーザに絞ってランキングを表示