### PR TITLE
ランキングロジックの改善 ph2

### DIFF
--- a/lib/application/user/health/update_health_interactor.dart
+++ b/lib/application/user/health/update_health_interactor.dart
@@ -40,7 +40,7 @@ class UpdateHealthInteractor implements UpdateHealthUsecase {
       if (updatedUser.health != health) {
         unawaited(
           _crashlytics.log(
-            'Getting Health Info may be failed [gotHealth][${health}][updateHealth][${updatedUser.health}]',
+            'Getting Health Info may be failed [gotHealth][$health][updateHealth][${updatedUser.health}]',
           ),
         );
       }

--- a/test/application/user/health/update_health_interactor_test.dart
+++ b/test/application/user/health/update_health_interactor_test.dart
@@ -144,7 +144,7 @@ void main() {
           ),
         ).called(1);
         verify(mockUserRepository.update(any)).called(1);
-        verify(mockFirebaseCrashlytics.log(any)).called(1);
+        verify(mockFirebaseCrashlytics.log(any)).called(2);
         verify(mockFirebaseCrashlytics.recordError(any, null)).called(1);
       });
 


### PR DESCRIPTION
@kmsz46 

daily のランキングにおいて、ユーザのヘルスケア情報がランキング集計当日に変更されていた場合、前日のデータを参照し、昨日に変更されていた場合は当日のデータを参照し、一昨日以前に更新されていた場合は 0 歩 と扱うようにしました。