### PR TITLE
キャッシュ戦略の改善

### DIFF
--- a/lib/application/pilgrimage/temple_repository.dart
+++ b/lib/application/pilgrimage/temple_repository.dart
@@ -5,14 +5,11 @@ import 'package:virtualpilgrimage/infrastructure/pilgrimage/temple_repository_im
 import '../../domain/pilgrimage/temple_info.codegen.dart';
 
 final templeRepositoryProvider = Provider<TempleRepository>(
-  (ref) => TempleRepositoryImpl(
-    ref.read(firestoreProvider),
-    ref,
-  ),
+  (ref) => TempleRepositoryImpl(ref.read(firestoreProvider)),
 );
 
 abstract class TempleRepository {
   Future<TempleInfo> getTempleInfo(int templeId);
 
-  Future<void> getTempleInfoAll();
+  Future<List<TempleInfo>> getTempleInfoWithPaging({required int limit});
 }

--- a/lib/infrastructure/user/user_repository_impl.dart
+++ b/lib/infrastructure/user/user_repository_impl.dart
@@ -79,8 +79,8 @@ class UserRepositoryImpl extends UserRepository {
               VirtualPilgrimageUser.fromJson(snapshot.data()!),
           toFirestore: (VirtualPilgrimageUser user, _) => user.toJson(),
         );
-    // よくデータが更新されるので、キャッシュを使わないようにsourceをserverだけにしている
-    final snapshot = await ref.get(const GetOptions(source: Source.server));
+    // 存在可否にしか使っていないので、キャッシュが使える場合はキャッシュを使う
+    final snapshot = await ref.get(const GetOptions(source: Source.serverAndCache));
     if (snapshot.size == 0) {
       return null;
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,7 +34,6 @@ class _App extends ConsumerWidget {
     final analytics = ref.read(analyticsProvider);
     final userState = ref.watch(userStateProvider.notifier);
     final loginState = ref.watch(loginStateProvider.notifier);
-    // final userIconRepository = ref.read(userIconRepositoryProvider);
 
     // Firebaseへのログインがキャッシュされていれば
     // Firestoreからユーザ情報を詰める
@@ -43,11 +42,6 @@ class _App extends ConsumerWidget {
       ref.read(userRepositoryProvider).get(firebaseAuth.currentUser!.uid).then((value) {
         if (value != null) {
           analytics.setUserProperties(user: value);
-          // 一旦、ピン画像は更新しないようにしている
-          // userIconRepository.loadIconImage(value.userIconUrl).then((bitmap) {
-          //   value = value!.setUserIconBitmap(bitmap);
-          //   userState.state = value;
-          // });
           userState.state = value;
           loginState.state = value.userStatus;
         }

--- a/lib/ui/pages/home/home_presenter.dart
+++ b/lib/ui/pages/home/home_presenter.dart
@@ -47,8 +47,6 @@ class HomePresenter extends StateNotifier<HomeState> {
   /// 初期化処理
   /// 初期化時にユーザのヘルスケア情報を読み取ってDBに書き込む
   Future<void> initialize() async {
-    // ログインした時点でお寺の情報を取得する。初回のみこの処理で時間がかかる
-    final futureGetTempleInfoAllResult = _templeRepository.getTempleInfoAll();
     unawaited(_analytics.logEvent(eventName: AnalyticsEvent.initializeHomePageAndGetHealth));
 
     final loginState = _ref.read(loginStateProvider);
@@ -120,8 +118,6 @@ class HomePresenter extends StateNotifier<HomeState> {
         unawaited(_analytics.logEvent(eventName: AnalyticsEvent.reachTemple));
       }
 
-      // むやみやたらにFirestoreに問い合わせないようにお寺情報取得が完了するのを待つ
-      await Future.wait([futureGetTempleInfoAllResult]);
       // 最後に過去の移動経路を可視化する
       await setMarkerAndPolylines(user: user, logicResult: logicResult, updatePastPolylines: true);
     } on Exception catch (e) {

--- a/lib/ui/pages/temple/temple_page.dart
+++ b/lib/ui/pages/temple/temple_page.dart
@@ -37,16 +37,45 @@ class _TemplePageBody extends StatelessWidget {
   Widget build(BuildContext context) {
     final state = ref.watch(templeProvider).temples;
     final scrollController = ref.read(templeProvider).scrollController;
+    final isLoading = ref.watch(templeProvider).loading;
     final user = ref.watch(userStateProvider);
 
     return ColoredBox(
       color: Theme.of(context).backgroundColor,
-      child: ListView.builder(
-        controller: scrollController,
-        itemBuilder: (BuildContext context, int index) {
-          return _buildTemple(context, state[index], user);
-        },
-        itemCount: state.length,
+      child: SizedBox(
+        width: double.maxFinite,
+        height: double.maxFinite,
+        child: Stack(
+          children: [
+            Opacity(
+              // 読み込み中は背景を透過させてローディングを目立たせる
+              opacity: isLoading ? 0.25 : 1,
+              child: SizedBox(
+                height: double.maxFinite,
+                child: ListView.builder(
+                  shrinkWrap: true,
+                  controller: scrollController,
+                  itemBuilder: (BuildContext context, int index) {
+                    return _buildTemple(context, state[index], user);
+                  },
+                  itemCount: state.length,
+                ),
+              ),
+            ),
+            if (isLoading)
+              Center(
+                child: SizedBox(
+                  height: 120,
+                  width: 120,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 16,
+                    color: Theme.of(context).colorScheme.primary,
+                    backgroundColor: Theme.of(context).colorScheme.onPrimary,
+                  ),
+                ),
+              )
+          ],
+        ),
       ),
     );
   }

--- a/lib/ui/pages/temple/temple_presenter.dart
+++ b/lib/ui/pages/temple/temple_presenter.dart
@@ -1,48 +1,64 @@
-import 'dart:collection';
+import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:virtualpilgrimage/application/pilgrimage/temple_repository.dart';
+import 'package:virtualpilgrimage/domain/exception/database_exception.dart';
 import 'package:virtualpilgrimage/domain/pilgrimage/temple_info.codegen.dart';
-import 'package:virtualpilgrimage/infrastructure/pilgrimage/temple_repository_impl.dart';
+import 'package:virtualpilgrimage/infrastructure/firebase/firebase_crashlytics_provider.dart';
 import 'package:virtualpilgrimage/ui/pages/temple/temple_state.codegen.dart';
 
 final templeProvider = StateNotifierProvider<TemplePresenter, TempleState>(TemplePresenter.new);
 
 class TemplePresenter extends StateNotifier<TempleState> {
   TemplePresenter(this._ref) : super(TempleState(scrollController: ScrollController())) {
-    // home page でお寺情報の読み込みが完了していない時のために念の為、repositoryからお寺情報を全て取得してキャッシュしておく
-    _ref.read(templeRepositoryProvider).getTempleInfoAll();
-    // 1番札所からソートして格納
-    _temples = SplayTreeMap.from(_ref.watch(templeInfoCache), (a, b) => a.compareTo(b));
-
+    _templeRepository = _ref.read(templeRepositoryProvider);
     // 1番端までスクロールしたら表示するお寺情報数を増やす
-    // 徐々に表示する情報を増やすことで、画像の読み込みを1度に最大10件までに抑えることができる
+    // 徐々に表示する情報を増やすことで、画像の読み込みを1度に最大8件までに抑えることができる
     state.addListener(() {
       if (state.scrollController.offset == state.scrollController.position.maxScrollExtent) {
         fetchTempleInfo();
       }
     });
+
     fetchTempleInfo();
   }
 
   final Ref _ref;
-  late final Map<int, TempleInfo> _temples;
+  late final TempleRepository _templeRepository;
+  List<TempleInfo> _temples = [];
 
   int loadedTempleImageIdSnapshot = 0;
 
   // 一度に読み込む情報の数
   final int fetchOnceLoadingNumber = 8;
 
+  // 札所情報の上限数
+  final int maxTempleNumber = 88;
+
   /// 札所の情報を一部読み込む
   ///
   /// 実際に読み込む情報はcacheされているので、次にページで読み込みたい札所の数を取得して、キャッシュから情報を返すだけ
   Future<void> fetchTempleInfo() async {
+    // 既に全ての情報を読み込み済みだったら何もしない
+    if (loadedTempleImageIdSnapshot == maxTempleNumber) {
+      return;
+    }
+    state = state.toLoading();
     // min(現在の読み込み件数 + 8, 札所情報の上限)
-    final int maxLoadingNumber =
-        min(loadedTempleImageIdSnapshot + fetchOnceLoadingNumber, _temples.length);
-    loadedTempleImageIdSnapshot = maxLoadingNumber;
-    state = state.updateTemples(_temples.values.toList().sublist(0, maxLoadingNumber));
+    loadedTempleImageIdSnapshot =
+        min(loadedTempleImageIdSnapshot + fetchOnceLoadingNumber, maxTempleNumber);
+    try {
+      final newTemples =
+          await _templeRepository.getTempleInfoWithPaging(limit: fetchOnceLoadingNumber);
+      // 重複を排除してリスト化し、1番札所からソートして格納
+      _temples = [...{..._temples, ...newTemples}];
+      _temples.sort((a, b) => a.id > b.id ? 1 : -1);
+      state = state.updateTemples(_temples).endLoading();
+    } on DatabaseException catch (exception) {
+      unawaited(_ref.read(firebaseCrashlyticsProvider).recordError(exception, null));
+      state = state.endLoading();
+    }
   }
 }

--- a/lib/ui/pages/temple/temple_state.codegen.dart
+++ b/lib/ui/pages/temple/temple_state.codegen.dart
@@ -9,11 +9,16 @@ class TempleState with _$TempleState {
   const factory TempleState({
     @Default([]) List<TempleInfo> temples,
     required ScrollController scrollController,
+    @Default(false) bool loading,
   }) = _TempleState;
 
   const TempleState._();
 
   TempleState updateTemples(List<TempleInfo> temples) => copyWith(temples: temples);
+
+  TempleState toLoading() => copyWith(loading: true);
+
+  TempleState endLoading() => copyWith(loading: false);
 
   void addListener(VoidCallback listener) => scrollController.addListener(listener);
 }

--- a/lib/ui/pages/temple/temple_state.codegen.freezed.dart
+++ b/lib/ui/pages/temple/temple_state.codegen.freezed.dart
@@ -18,6 +18,7 @@ final _privateConstructorUsedError = UnsupportedError(
 mixin _$TempleState {
   List<TempleInfo> get temples => throw _privateConstructorUsedError;
   ScrollController get scrollController => throw _privateConstructorUsedError;
+  bool get loading => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $TempleStateCopyWith<TempleState> get copyWith =>
@@ -30,7 +31,10 @@ abstract class $TempleStateCopyWith<$Res> {
           TempleState value, $Res Function(TempleState) then) =
       _$TempleStateCopyWithImpl<$Res, TempleState>;
   @useResult
-  $Res call({List<TempleInfo> temples, ScrollController scrollController});
+  $Res call(
+      {List<TempleInfo> temples,
+      ScrollController scrollController,
+      bool loading});
 }
 
 /// @nodoc
@@ -48,6 +52,7 @@ class _$TempleStateCopyWithImpl<$Res, $Val extends TempleState>
   $Res call({
     Object? temples = null,
     Object? scrollController = null,
+    Object? loading = null,
   }) {
     return _then(_value.copyWith(
       temples: null == temples
@@ -58,6 +63,10 @@ class _$TempleStateCopyWithImpl<$Res, $Val extends TempleState>
           ? _value.scrollController
           : scrollController // ignore: cast_nullable_to_non_nullable
               as ScrollController,
+      loading: null == loading
+          ? _value.loading
+          : loading // ignore: cast_nullable_to_non_nullable
+              as bool,
     ) as $Val);
   }
 }
@@ -70,7 +79,10 @@ abstract class _$$_TempleStateCopyWith<$Res>
       __$$_TempleStateCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({List<TempleInfo> temples, ScrollController scrollController});
+  $Res call(
+      {List<TempleInfo> temples,
+      ScrollController scrollController,
+      bool loading});
 }
 
 /// @nodoc
@@ -86,6 +98,7 @@ class __$$_TempleStateCopyWithImpl<$Res>
   $Res call({
     Object? temples = null,
     Object? scrollController = null,
+    Object? loading = null,
   }) {
     return _then(_$_TempleState(
       temples: null == temples
@@ -96,6 +109,10 @@ class __$$_TempleStateCopyWithImpl<$Res>
           ? _value.scrollController
           : scrollController // ignore: cast_nullable_to_non_nullable
               as ScrollController,
+      loading: null == loading
+          ? _value.loading
+          : loading // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -105,7 +122,8 @@ class __$$_TempleStateCopyWithImpl<$Res>
 class _$_TempleState extends _TempleState {
   const _$_TempleState(
       {final List<TempleInfo> temples = const [],
-      required this.scrollController})
+      required this.scrollController,
+      this.loading = false})
       : _temples = temples,
         super._();
 
@@ -119,10 +137,13 @@ class _$_TempleState extends _TempleState {
 
   @override
   final ScrollController scrollController;
+  @override
+  @JsonKey()
+  final bool loading;
 
   @override
   String toString() {
-    return 'TempleState(temples: $temples, scrollController: $scrollController)';
+    return 'TempleState(temples: $temples, scrollController: $scrollController, loading: $loading)';
   }
 
   @override
@@ -132,12 +153,13 @@ class _$_TempleState extends _TempleState {
             other is _$_TempleState &&
             const DeepCollectionEquality().equals(other._temples, _temples) &&
             (identical(other.scrollController, scrollController) ||
-                other.scrollController == scrollController));
+                other.scrollController == scrollController) &&
+            (identical(other.loading, loading) || other.loading == loading));
   }
 
   @override
   int get hashCode => Object.hash(runtimeType,
-      const DeepCollectionEquality().hash(_temples), scrollController);
+      const DeepCollectionEquality().hash(_temples), scrollController, loading);
 
   @JsonKey(ignore: true)
   @override
@@ -149,13 +171,16 @@ class _$_TempleState extends _TempleState {
 abstract class _TempleState extends TempleState {
   const factory _TempleState(
       {final List<TempleInfo> temples,
-      required final ScrollController scrollController}) = _$_TempleState;
+      required final ScrollController scrollController,
+      final bool loading}) = _$_TempleState;
   const _TempleState._() : super._();
 
   @override
   List<TempleInfo> get temples;
   @override
   ScrollController get scrollController;
+  @override
+  bool get loading;
   @override
   @JsonKey(ignore: true)
   _$$_TempleStateCopyWith<_$_TempleState> get copyWith =>

--- a/test/helper/fakes/fake_temple_repository.dart
+++ b/test/helper/fakes/fake_temple_repository.dart
@@ -2,17 +2,18 @@ import 'package:virtualpilgrimage/application/pilgrimage/temple_repository.dart'
 import 'package:virtualpilgrimage/domain/pilgrimage/temple_info.codegen.dart';
 
 class FakeTempleRepository extends TempleRepository {
-  FakeTempleRepository(this.templeInfo);
+  FakeTempleRepository(this.temples);
 
-  final TempleInfo templeInfo;
+  final Map<int, TempleInfo> temples;
 
   @override
   Future<TempleInfo> getTempleInfo(int templeId) {
-    return Future.value(templeInfo);
+    final temple = temples[templeId];
+    return Future.value(temple ?? temples.values.first);
   }
 
   @override
-  Future<void> getTempleInfoAll() {
-    return Future.value();
+  Future<List<TempleInfo>> getTempleInfoWithPaging({required int limit}) {
+    return Future.value(temples.values.toList());
   }
 }

--- a/test/infrastructure/pilgrimage/temple_repository_impl_test.dart
+++ b/test/infrastructure/pilgrimage/temple_repository_impl_test.dart
@@ -5,10 +5,8 @@ import 'package:mockito/mockito.dart';
 import 'package:virtualpilgrimage/application/pilgrimage/temple_repository.dart';
 import 'package:virtualpilgrimage/domain/pilgrimage/temple_info.codegen.dart';
 import 'package:virtualpilgrimage/infrastructure/firebase/firestore_provider.dart';
-import 'package:virtualpilgrimage/infrastructure/pilgrimage/temple_repository_impl.dart';
 
 import '../../helper/mock.mocks.dart';
-import '../../helper/mock_query_document_snapshot.dart';
 import '../../helper/provider_container.dart';
 
 void main() {
@@ -20,8 +18,6 @@ void main() {
   late MockCollectionReference<Map<String, dynamic>> mockCollectionReference;
   late MockDocumentReference<TempleInfo> mockTempleInfoDocumentReference;
   late MockDocumentReference<Map<String, dynamic>> mockMapDocumentReference;
-  late QueryDocumentSnapshot<Map<String, dynamic>> snapshot1;
-  late QueryDocumentSnapshot<Map<String, dynamic>> snapshot2;
 
   setUp(() {
     mockFirebaseFirestore = MockFirebaseFirestore();
@@ -35,8 +31,6 @@ void main() {
     mockCollectionReference = MockCollectionReference();
     mockMapDocumentReference = MockDocumentReference();
     mockTempleInfoDocumentReference = MockDocumentReference();
-    snapshot1 = MockQueryDocumentSnapshot({}, mockMapDocumentReference);
-    snapshot2 = MockQueryDocumentSnapshot({}, mockMapDocumentReference);
   });
 
   group('TempleRepositoryImpl', () {
@@ -52,7 +46,8 @@ void main() {
           toFirestore: anyNamed('toFirestore'),
         ),
       ).thenReturn(mockTempleInfoDocumentReference);
-      when(mockTempleInfoDocumentReference.get(const GetOptions(source: Source.serverAndCache))).thenAnswer(
+      when(mockTempleInfoDocumentReference.get(const GetOptions(source: Source.serverAndCache)))
+          .thenAnswer(
         (_) => Future.value(mockDocumentSnapshot),
       );
     });
@@ -72,38 +67,6 @@ void main() {
           expect(actual, expected);
           verify(mockFirebaseFirestore.collection('temples')).called(1);
         });
-        test('キャッシュからお寺の情報を取得できる', () async {
-          // given
-          container.read(templeInfoCache.notifier).state = {11: defaultTempleInfo(11)};
-
-          // when
-          final actual = await target.getTempleInfo(11);
-          expect(actual, defaultTempleInfo(11));
-          // Firestoreへの問い合わせを行なっていない
-          verifyNever(mockFirebaseFirestore.collection('temples')).called(0);
-        });
-      });
-    });
-
-    group('getTempleInfoAll', () {
-      final QuerySnapshot<Map<String, dynamic>> querySnapshot = MockQuerySnapshot();
-      test('正常系', () async {
-        // given
-        when(mockCollectionReference.get(const GetOptions(source: Source.serverAndCache))).thenAnswer((_) => Future.value(querySnapshot));
-        when(querySnapshot.docs).thenReturn([snapshot1, snapshot2]);
-        when(mockDocumentSnapshot.exists).thenReturn(true);
-        when(mockDocumentSnapshot.data()).thenReturn(defaultTempleInfo());
-
-        // when
-        await target.getTempleInfoAll();
-
-        // then
-        expect(container.read(templeInfoCache), {1: defaultTempleInfo()});
-        verify(mockFirebaseFirestore.collection('temples')).called(1);
-        verify(querySnapshot.docs).called(1);
-        verify(mockTempleInfoDocumentReference.get(const GetOptions(source: Source.serverAndCache))).called(2);
-        verify(mockDocumentSnapshot.exists).called(2);
-        verify(mockDocumentSnapshot.data()).called(2);
       });
     });
   });

--- a/test/infrastructure/user/user_repository_impl_test.dart
+++ b/test/infrastructure/user/user_repository_impl_test.dart
@@ -173,7 +173,7 @@ void main() {
         setUp(() {
           when(mockQuerySnapshot.docs).thenReturn(mockQueryDocumentSnapshots);
           when(mockQuerySnapshot.size).thenReturn(users.length);
-          when(mockQueryDomainUser.get(const GetOptions(source: Source.server))).thenAnswer(
+          when(mockQueryDomainUser.get(const GetOptions(source: Source.serverAndCache))).thenAnswer(
             (_) => Future.value(mockQuerySnapshot),
           );
           when(

--- a/test/ui/pages/home/home_presenter_test.dart
+++ b/test/ui/pages/home/home_presenter_test.dart
@@ -23,7 +23,7 @@ void main() {
       encodedPoints: '',
       stampImage: '1.png',
     );
-    templeRepository = FakeTempleRepository(templeInfo);
+    templeRepository = FakeTempleRepository({23: templeInfo});
     final container = mockedProviderContainer(
       overrides: [templeRepositoryProvider.overrideWithValue(templeRepository)],
     );

--- a/test/ui/pages/temple/temple_page_test.dart
+++ b/test/ui/pages/temple/temple_page_test.dart
@@ -1,20 +1,17 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
 import 'package:network_image_mock/network_image_mock.dart';
 import 'package:virtualpilgrimage/application/pilgrimage/temple_repository.dart';
 import 'package:virtualpilgrimage/domain/pilgrimage/temple_info.codegen.dart';
-import 'package:virtualpilgrimage/infrastructure/pilgrimage/temple_repository_impl.dart';
 import 'package:virtualpilgrimage/ui/pages/temple/temple_page.dart';
 
-import '../../../application/pilgrimage/update_pilgrimage_progress_interactor_test.mocks.dart';
+import '../../../helper/fakes/fake_temple_repository.dart';
 import '../../../helper/provider_container.dart';
 import '../../../helper/wrap_material_app.dart';
 
 void main() {
-  final templeRepository = MockTempleRepository();
-  when(templeRepository.getTempleInfoAll()).thenAnswer((_) => Future.value());
+  final templeRepository = FakeTempleRepository(createTempleInfoMap());
 
   // ダイアログの表示テストはwidgetテストの範囲に収まらないので、実装していない
   group('TemplePage', () {
@@ -27,12 +24,14 @@ void main() {
               const TemplePage(),
               overrides: [
                 templeRepositoryProvider.overrideWithValue(templeRepository),
-                templeInfoCache.overrideWith((_) => createTempleInfoMap()),
               ],
             ),
           ),
         ),
       );
+
+      await mockNetworkImagesFor(() => widgetTester.pump());
+
       expect(find.text('1番札所'), findsOneWidget);
       expect(find.text('霊山寺'), findsOneWidget);
       // スクロールしないと見えないはず
@@ -49,7 +48,6 @@ void main() {
               const TemplePage(),
               overrides: [
                 templeRepositoryProvider.overrideWithValue(templeRepository),
-                templeInfoCache.overrideWith((_) => createTempleInfoMap()),
               ],
             ),
           ),
@@ -61,6 +59,8 @@ void main() {
       final itemFinder = find.byKey(const ValueKey('temple_88'));
 
       await widgetTester.scrollUntilVisible(itemFinder, 1000, scrollable: listFinder);
+
+      await mockNetworkImagesFor(() => widgetTester.pump());
 
       // 末尾のお寺情報が見えているはず
       expect(itemFinder, findsOneWidget);


### PR DESCRIPTION
@itomizu 

現行のキャッシュ戦略だと、毎回 88 件の札所情報を取得しています。
アプリを開くたびに最低 88 + a(ユーザ情報やランキング情報取得の回数) 回の読み取り処理が走り、ユーザ数がある程度スケールするとすぐに firestore の無料枠である 5万回 read / 1day の制約を超えてしまいそうなので改善しました。

改善後は以下のようにしました。
- キャッシュ戦略を firestore のキャッシュに依存させる
  - ユーザ情報のみ、常に最新の値を取得したいので毎回サーバーから情報を取得
- 札所の情報は必要になるたびに firestore から取得(home page でもせいぜい 5 回くらいの読み取りしか発生しない。裏側で 88 件取得するのを待つより高速かつエコ)
- temple page では 8 件ずつ札所の情報を読み込むように修正。スクロールするたびに読み込むので、読み込みの UI も改善